### PR TITLE
redshift does not support sequences

### DIFF
--- a/redshift_sqlalchemy/dialect.py
+++ b/redshift_sqlalchemy/dialect.py
@@ -114,6 +114,8 @@ class RedShiftDDLCompiler(PGDDLCompiler):
 
 class RedshiftDialect(PGDialect_psycopg2):
     name = 'redshift'
+    supports_sequences = False
+    preexecute_autoincrement_sequences = False
     ddl_compiler = RedShiftDDLCompiler
 
     construct_arguments = [


### PR DESCRIPTION
Need to tell sqlalchemy to not use sequences, as they are not supported on redshift.  See issue #48 