### PR TITLE
Order columns by attnum to ensure proper ordering in reflected table

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,10 @@
   The `redshift_sqlalchemy` compatibility package will be removed
   in a future release.
   (`Issue #58 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/58>`_)
+- Fix a bug where reflected tables could have incorrect column order for some
+  `CREATE TABLE` statements, particularly for columns with an `IDENTITY`
+  constraint.
+  (`Issue #60 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/60>`_)
 - Fix a bug where reflecting a table could raise a ``NoSuchTableError``
   in cases where its schema is not on the current ``search_path``
   (`Issue #64 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/64>`_)

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -671,7 +671,7 @@ class RedshiftDialect(PGDialect_psycopg2):
             LEFT JOIN pg_catalog.pg_attrdef ad
               ON (att.attrelid, att.attnum) = (ad.adrelid, ad.adnum)
             WHERE n.nspname !~ '^pg_'
-            ORDER BY n.nspname, c.relname;
+            ORDER BY n.nspname, c.relname, att.attnum
             """)
             for col in result:
                 schema = col.schema

--- a/tests/rs_sqla_test_utils/models.py
+++ b/tests/rs_sqla_test_utils/models.py
@@ -102,6 +102,7 @@ class ReflectionIdentity(Base):
     __tablename__ = 'reflection_identity'
     col1 = sa.Column(sa.Integer(), primary_key=True)
     col2 = sa.Column(sa.Integer(), info={'identity': (1, 3)})
+    col3 = sa.Column(sa.Integer())
     __table_args__ = (
         {'redshift_diststyle': 'EVEN'}
     )

--- a/tests/test_reflection.py
+++ b/tests/test_reflection.py
@@ -73,6 +73,7 @@ models_and_ddls = [
     CREATE TABLE reflection_identity (
         col1 INTEGER NOT NULL,
         col2 INTEGER IDENTITY(1,3),
+        col3 INTEGER,
         PRIMARY KEY (col1)
     ) DISTSTYLE EVEN
     """),


### PR DESCRIPTION
`IDENTITY` columns were being put at the end of reflected `CREATE TABLE` statements, regardless of their actual order in the original table definition.