### PR TITLE
Add failing test for reflection regression introduced in 1b911f25bf4906788b5

### DIFF
--- a/tests/rs_sqla_test_utils/models.py
+++ b/tests/rs_sqla_test_utils/models.py
@@ -14,6 +14,14 @@ class Basic(Base):
     )
 
 
+class BasicInSchema(Base):
+    __tablename__ = 'schema.basic'
+    col1 = sa.Column(
+        sa.Integer(), primary_key=True,
+        info={'distkey': True, 'sortkey': True}
+    )
+
+
 class ReflectionDistKey(Base):
     __tablename__ = 'reflection_distkey'
     col1 = sa.Column(sa.Integer(), primary_key=True)

--- a/tests/test_reflection.py
+++ b/tests/test_reflection.py
@@ -76,6 +76,12 @@ models_and_ddls = [
         PRIMARY KEY (col1)
     ) DISTSTYLE EVEN
     """),
+    (models.BasicInSchema, """
+    CREATE TABLE schema.basic (
+        col INTEGER NOT NULL,
+        PRIMARY KEY (col1)
+    ) DISTSTYLE KEY DISTKEY (col1)
+    """),
     pytest.mark.xfail((models.ReflectionDelimitedIdentifiers1, '''
     CREATE TABLE "group" (
         "this ""is it""" INTEGER NOT NULL,


### PR DESCRIPTION
https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/commit/1b911f25bf4906788b5bdca0199c587e9d256cf6
Introduced a regression, and now I cannot reflect anymore some tables.

I had a look, and I suspect that the problem might be because there's no test that checks for a table inside a schema. I tried to add a test, and I opened this PR hoping that Travis would run it (unfortunately I forgot that due to security reason, the secure variables are used only with commits made by the repo's owner)