### PR TITLE
DISTKEY and SORTKEY should be in quotations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,11 @@
 
 - Support reflecting tables with foriegn keys to tables in non-public schemas
   (`Issue #70 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/70>`_)
+- Fix a bug where DISTKEY and SORTKEY could not be used on column names containing
+  spaces or commas. This is a breaking behavioral change for a command like
+  `__table_args__ = {'redshift_sortkey': ('foo, bar')}`. Previously, this would sort
+  on the columns named `foo` and `bar`. Now, it sorts on the column named `foo, bar`.
+  (`Issue #74 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/74>`_)
 
 
 0.4.0 (2015-11-17)

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -241,7 +241,7 @@ class RedshiftDDLCompiler(PGDDLCompiler):
 
         distkey = info.get('distkey')
         if distkey:
-            text += " DISTKEY ({0})".format(distkey)
+            text += " DISTKEY ({0})".format(self.preparer.quote(distkey))
 
         sortkey = info.get('sortkey')
         interleaved_sortkey = info.get('interleaved_sortkey')
@@ -259,7 +259,9 @@ class RedshiftDDLCompiler(PGDDLCompiler):
                     for key in keys]
             if interleaved_sortkey:
                 text += " INTERLEAVED"
-            text += " SORTKEY ({0})".format(", ".join(keys))
+            sortkey_string = ", ".join(self.preparer.quote(key)
+                                       for key in keys)
+            text += " SORTKEY ({0})".format(sortkey_string)
         return text
 
     def get_column_specification(self, column, **kwargs):

--- a/tests/rs_sqla_test_utils/models.py
+++ b/tests/rs_sqla_test_utils/models.py
@@ -44,7 +44,7 @@ class ReflectionSortKey(Base):
     col2 = sa.Column(sa.Integer())
     __table_args__ = (
         {'redshift_diststyle': 'EVEN',
-         'redshift_sortkey': ('col1, col2')}
+         'redshift_sortkey': ('col1', 'col2')}
     )
 
 
@@ -56,6 +56,16 @@ class ReflectionInterleavedSortKey(Base):
         {'redshift_diststyle': 'EVEN',
          'redshift_interleaved_sortkey': (col1, col2)}
     )
+
+
+class ReflectionSortKeyDistKeyWithSpaces(Base):
+    __tablename__ = 'sort_key_with_spaces'
+    col1 = sa.Column('col with spaces', sa.Integer(), primary_key=True)
+    __table_args__ = {
+        'redshift_diststyle': 'EVEN',
+        'redshift_sortkey': 'col with spaces',
+        'redshift_distkey': 'col with spaces',
+    }
 
 
 class ReflectionUniqueConstraint(Base):

--- a/tests/test_reflection.py
+++ b/tests/test_reflection.py
@@ -36,6 +36,12 @@ models_and_ddls = [
         PRIMARY KEY (col1)
     ) DISTSTYLE EVEN INTERLEAVED SORTKEY (col1, col2)
     """),
+    (models.ReflectionSortKeyDistKeyWithSpaces, """
+    CREATE TABLE sort_key_with_spaces (
+        "col with spaces" INTEGER NOT NULL,
+        PRIMARY KEY ("col with spaces")
+    ) DISTSTYLE EVEN DISTKEY ("col with spaces") SORTKEY ("col with spaces")
+    """),
     (models.ReflectionUniqueConstraint, """
     CREATE TABLE reflection_unique_constraint (
         col1 INTEGER NOT NULL,


### PR DESCRIPTION
Redshift column names can contain spaces. A column name like `Foo Bar` will become a sql statement looking like this
```
SORTKEY (Foo Bar)
```
which will fail. This PR quotify's DISTKEY and SORTKEY, so they will appear like this:
```
SORTKEY ("Foo Bar")
```