### PR TITLE
Fix composite foreign key reflection

### DIFF
--- a/tests/rs_sqla_test_utils/models.py
+++ b/tests/rs_sqla_test_utils/models.py
@@ -89,6 +89,21 @@ class ReflectionForeignKeyConstraint(Base):
     )
 
 
+class ReflectionCompositeForeignKeyConstraint(Base):
+    __tablename__ = 'reflection_composite_fk_constraint'
+    id = sa.Column(sa.Integer(),
+                   primary_key=True)
+    col1 = sa.Column(sa.Integer())
+    col2 = sa.Column(sa.Integer())
+    __table_args__ = (
+        sa.ForeignKeyConstraint(
+            ['col1', 'col2'],
+            ['reflection_pk_constraint.col1', 'reflection_pk_constraint.col2']
+        ),
+        {'redshift_diststyle': 'EVEN'}
+    )
+
+
 class ReflectionDefaultValue(Base):
     __tablename__ = 'reflection_default_value'
     col1 = sa.Column(sa.Integer(), primary_key=True)

--- a/tests/test_reflection.py
+++ b/tests/test_reflection.py
@@ -108,6 +108,16 @@ models_and_ddls = [
         PRIMARY KEY (id)
     ) DISTSTYLE EVEN
     '''),
+    (models.ReflectionCompositeForeignKeyConstraint, '''
+    CREATE TABLE reflection_composite_fk_constraint (
+        id INTEGER NOT NULL,
+        col1 INTEGER,
+        col2 INTEGER,
+        PRIMARY KEY (id),
+        FOREIGN KEY(col1, col2)
+        REFERENCES reflection_pk_constraint (col1, col2)
+    ) DISTSTYLE EVEN
+    '''),
 ]
 
 


### PR DESCRIPTION
This fixes a bug I came across when using composite foreign keys in redshift tables and then reflecting against them, I updated the tests, but you can also reproduce and verify by doing the following:

```python
metadata = sa.MetaData()
engine = sa.create_engine('redshift+psycopg2://awesome.redshift.uri/...')
referenced = sa.Table('referenced', metadata,
                      sa.Column('col1', sa.Integer, primary_key=True),
                      sa.Column('col2', sa.Integer, primary_key=True),
                      redshift_distkey='col1',
                      redshift_sortkey=['col1','col2'])
composite_fk_table = sa.Table('composite_fk', metadata,
                              sa.Column('id', sa.Integer, primary_key=True),
                              sa.Column('col1', sa.Integer),
                              sa.Column('col2', sa.Integer),
                              sa.ForeignKeyConstraint(['col1', 'col2'], ['referenced.col1', 'referenced.col2']),
                              redshift_distkey='id',
                              redshift_sortkey='id')
metadata.create_all(bind=engine)
metadata.clear()
# raises AttributeError: 'NoneType' object has no attribute 'group'
reflected = sa.Table('composite_fk', metadata, autoload=True, autoload_with=engine)
assert [fk.target_fullname for fk in reflected.foreign_keys] == ['referenced.col1', 'referenced.col2']
```