### PR TITLE
Table identifier

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@
   (`Issue #88 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/88>`_)
 - Increase max_identifier_length to 127 characters
   (`Issue #96 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/issues/96>`_)
+- Fix a bug where table names containing a period caused an error on reflection
+  (`Issue #97 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/97>`_)
+
 
 0.5.0 (2016-04-21)
 ------------------

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -107,11 +107,14 @@ def _get_relation_key(name, schema):
 def _get_schema_and_relation(key):
     if '.' not in key:
         return (None, key)
-    identifiers = SQL_IDENTIFIER_RE.findall(key)
+
+    # capture and split on anything that's not a period or double quote OR
+    # something that is anything in double quotes
+    identifiers = re.split(r'''((?:[^."]|"[^"]*")+)''', key)[1::2]
     if len(identifiers) == 1:
         return (None, key)
     elif len(identifiers) == 2:
-        return identifiers
+        return tuple(identifiers)
     raise ValueError("%s does not look like a valid relation identifier")
 
 
@@ -321,7 +324,6 @@ class RedshiftDialect(PGDialect_psycopg2):
 
     statement_compiler = RedshiftCompiler
     ddl_compiler = RedshiftDDLCompiler
-
     construct_arguments = [
         (schema.Index, {
             "using": False,

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -1,9 +1,9 @@
 import re
-from collections import defaultdict
+from collections import defaultdict, namedtuple
 
 import pkg_resources
 import sqlalchemy as sa
-from sqlalchemy import Column, exc, inspect, schema
+from sqlalchemy import Column, exc, inspect
 from sqlalchemy.dialects.postgresql.base import PGCompiler, PGDDLCompiler
 from sqlalchemy.dialects.postgresql.psycopg2 import PGDialect_psycopg2
 from sqlalchemy.engine import reflection
@@ -97,38 +97,40 @@ PRIMARY_KEY_RE = re.compile(r"""
 """, re.VERBOSE)
 
 
-def _get_relation_key(name, schema):
-    if schema is None:
-        return name
-    else:
-        return schema + "." + name
-
-
-def _get_schema_and_relation(key):
-    if '.' not in key:
-        return (None, key)
-
-    # capture and split on anything that's not a period or double quote OR
-    # something that is anything in double quotes
-    identifiers = re.split(r'''((?:[^."]|"[^"]*")+)''', key)[1::2]
-    if len(identifiers) == 1:
-        return (None, key)
-    elif len(identifiers) == 2:
-        return tuple(identifiers)
-    raise ValueError("%s does not look like a valid relation identifier")
-
-
-def unquoted(key):
+class RelationKey(namedtuple('RelationKey', ('name', 'schema'))):
     """
-    Return *key* with one level of double quotes removed.
-
-    Redshift stores some identifiers without quotes in internal tables,
-    even though the name must be quoted elsewhere.
-    In particular, this happens for tables named as a keyword.
+    Structured tuple of table/view name and schema name.
     """
-    if key.startswith('"') and key.endswith('"'):
-        return key[1:-1]
-    return key
+    __slots__ = ()
+
+    def __new__(cls, name, schema=None, connection=None):
+        """
+        Construct a new RelationKey with an explicit schema name.
+        """
+        if schema is None and connection is None:
+            raise ValueError("Must specify either schema or connection")
+        if schema is None:
+            schema = inspect(connection).default_schema_name
+        return super(RelationKey, cls).__new__(cls, name, schema)
+
+    def __str__(self):
+        if self.schema is None:
+            return self.name
+        else:
+            return self.schema + "." + self.name
+
+    def unquoted(self):
+        """
+        Return *key* with one level of double quotes removed.
+
+        Redshift stores some identifiers without quotes in internal tables,
+        even though the name must be quoted elsewhere.
+        In particular, this happens for tables named as a keyword.
+        """
+        key = str(self)
+        if key.startswith('"') and key.endswith('"'):
+            return key[1:-1]
+        return key
 
 
 class RedshiftCompiler(PGCompiler):
@@ -325,12 +327,12 @@ class RedshiftDialect(PGDialect_psycopg2):
     statement_compiler = RedshiftCompiler
     ddl_compiler = RedshiftDDLCompiler
     construct_arguments = [
-        (schema.Index, {
+        (sa.schema.Index, {
             "using": False,
             "where": None,
             "ops": {}
         }),
-        (schema.Table, {
+        (sa.schema.Table, {
             "ignore_search_path": False,
             "diststyle": None,
             "distkey": None,
@@ -553,11 +555,8 @@ class RedshiftDialect(PGDialect_psycopg2):
                                                     info_cache=info_cache)
         relation_names = []
         for key, relation in all_relations.items():
-            this_schema, this_relation = _get_schema_and_relation(key)
-            if this_schema is None:
-                this_schema = default_schema
-            if this_schema == schema and relation.relkind == relkind:
-                relation_names.append(this_relation)
+            if key.schema == schema and relation.relkind == relkind:
+                relation_names.append(key.name)
         return relation_names
 
     def _get_column_info(self, *args, **kwargs):
@@ -581,9 +580,9 @@ class RedshiftDialect(PGDialect_psycopg2):
         info_cache = kw.get('info_cache')
         all_relations = self._get_all_relation_info(connection,
                                                     info_cache=info_cache)
-        key = _get_relation_key(table_name, schema)
+        key = RelationKey(table_name, schema, connection)
         if key not in all_relations.keys():
-            key = unquoted(key)
+            key = key.unquoted()
         try:
             return all_relations[key]
         except KeyError:
@@ -593,9 +592,9 @@ class RedshiftDialect(PGDialect_psycopg2):
         info_cache = kw.get('info_cache')
         all_columns = self._get_all_column_info(connection,
                                                 info_cache=info_cache)
-        key = _get_relation_key(table_name, schema)
+        key = RelationKey(table_name, schema, connection)
         if key not in all_columns.keys():
-            key = unquoted(key)
+            key = key.unquoted()
         return all_columns[key]
 
     def _get_redshift_constraints(self, connection, table_name,
@@ -603,9 +602,9 @@ class RedshiftDialect(PGDialect_psycopg2):
         info_cache = kw.get('info_cache')
         all_constraints = self._get_all_constraint_info(connection,
                                                         info_cache=info_cache)
-        key = _get_relation_key(table_name, schema)
+        key = RelationKey(table_name, schema, connection)
         if key not in all_constraints.keys():
-            key = unquoted(key)
+            key = key.unquoted()
         return all_constraints[key]
 
     @reflection.cache
@@ -634,10 +633,7 @@ class RedshiftDialect(PGDialect_psycopg2):
         """)
         relations = {}
         for rel in result:
-            schema = rel.schema
-            if schema == inspect(connection).default_schema_name:
-                schema = None
-            key = _get_relation_key(rel.relname, schema)
+            key = RelationKey(rel.relname, rel.schema, connection)
             relations[key] = rel
         return relations
 
@@ -687,10 +683,7 @@ class RedshiftDialect(PGDialect_psycopg2):
             ORDER BY n.nspname, c.relname, att.attnum
             """)
             for col in result:
-                schema = col.schema
-                if schema == inspect(connection).default_schema_name:
-                    schema = None
-                key = _get_relation_key(col.table_name, schema)
+                key = RelationKey(col.table_name, col.schema, connection)
                 all_columns[key].append(col)
 
             cc.execute("SET LOCAL search_path TO %s" % search_path)
@@ -723,10 +716,7 @@ class RedshiftDialect(PGDialect_psycopg2):
         """)
         all_constraints = defaultdict(list)
         for con in result:
-            schema = con.schema
-            if schema == inspect(connection).default_schema_name:
-                schema = None
-            key = _get_relation_key(con.table_name, schema)
+            key = RelationKey(con.table_name, con.schema, connection)
             all_constraints[key].append(con)
         return all_constraints
 

--- a/tests/rs_sqla_test_utils/models.py
+++ b/tests/rs_sqla_test_utils/models.py
@@ -159,6 +159,24 @@ class ReflectionDelimitedIdentifiers2(Base):
     )
 
 
+class ReflectionDelimitedTableName(Base):
+    __tablename__ = 'this.table'
+    col1 = sa.Column('id', sa.Integer(), primary_key=True)
+    __table_args__ = (
+        {'redshift_diststyle': 'EVEN',
+         'schema': 'other_schema'}
+    )
+
+
+class ReflectionDelimitedTableNoSchema(Base):
+    __tablename__ = 'this.table'
+    col1 = sa.Column('id', sa.Integer(), primary_key=True)
+    __table_args__ = (
+        {'redshift_diststyle': 'EVEN',
+         'schema': None}
+    )
+
+
 class Referenced(Base):
     __tablename__ = 'referenced'
     id = sa.Column(

--- a/tests/test_reflection.py
+++ b/tests/test_reflection.py
@@ -166,20 +166,3 @@ def test_no_search_path_leak(redshift_session):
     result = redshift_session.execute("SHOW search_path")
     search_path = result.scalar()
     assert 'other_schema' not in search_path
-
-
-def test_splitting_schema_and_relation():
-    cases = [
-        ("other_schema.\"table.name\"", ("other_schema", "\"table.name\"")),
-        ("\"table.name\"", (None, "\"table.name\"")),
-        ("schema.\"this \"\"is it\"\"\"",
-         ("schema", "\"this \"\"is it\"\"\"")),
-        ("\"this \"\"is it\"\"\"", (None, "\"this \"\"is it\"\"\"")),
-        # the delimited identifier dox is silent on whether the following is
-        # possible
-        (("\"crazy schema\".\"crazy table\""),
-         ("\"crazy schema\"", "\"crazy table\"")),
-    ]
-
-    for case, expected in cases:
-        assert dialect._get_schema_and_relation(case) == expected


### PR DESCRIPTION
## Todos
- [x] MIT compatible
- [x] Tests
- [x] Documentation
- [x] Updated CHANGES.rst

This builds on #78 and avoids the trouble of parsing qualified table names by instead introducing a `RelationKey` namedtuple that tracks those values separately.

Does this look like a good approach?
