### PR TITLE
max_identifier_length = 127

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@
 
 - Support role-based access control in COPY and UNLOAD commands
   (`Issue #88 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/88>`_)
+- Support 127 character column names instead of 63 characters (postgres default)
+  (`Pull #98 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/98>`_)
 
 0.5.0 (2016-04-21)
 ------------------

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -320,6 +320,7 @@ class RedshiftDialect(PGDialect_psycopg2):
 
     statement_compiler = RedshiftCompiler
     ddl_compiler = RedshiftDDLCompiler
+    max_identifier_length = 127
 
     construct_arguments = [
         (schema.Index, {


### PR DESCRIPTION
This PR changes the max length for column names from the postgres inherrited default of 63 characters to the proper redshift maximum of 127 characters.

## Todos
- [x] MIT compatible
- [ ] Tests
- [ ] Documentation
- [x] Updated CHANGES.rst

