### PR TITLE
Pass in info_cache when querying constraints.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@
   (`Issue #96 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/issues/96>`_)
 - Fix a bug where table names containing a period caused an error on reflection
   (`Issue #97 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/97>`_)
+- Performance improvement for reflection by caching table constraint info
+  (`Issue #101 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/issues/101>`_)
 
 
 0.5.0 (2016-04-21)

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -377,7 +377,7 @@ class RedshiftDialect(PGDialect_psycopg2):
         :meth:`~sqlalchemy.engine.interfaces.Dialect.get_pk_constraint`.
         """
         constraints = self._get_redshift_constraints(connection, table_name,
-                                                     schema)
+                                                     schema, **kw)
         pk_constraints = [c for c in constraints if c.contype == 'p']
         if not pk_constraints:
             return {'constrained_columns': [], 'name': ''}
@@ -399,7 +399,7 @@ class RedshiftDialect(PGDialect_psycopg2):
         :meth:`~sqlalchemy.engine.interfaces.Dialect.get_pk_constraint`.
         """
         constraints = self._get_redshift_constraints(connection, table_name,
-                                                     schema)
+                                                     schema, **kw)
         fk_constraints = [c for c in constraints if c.contype == 'f']
         uniques = defaultdict(lambda: defaultdict(dict))
         for con in fk_constraints:
@@ -478,7 +478,7 @@ class RedshiftDialect(PGDialect_psycopg2):
         :meth:`~sqlalchemy.engine.interfaces.Dialect.get_unique_constraints`.
         """
         constraints = self._get_redshift_constraints(connection,
-                                                     table_name, schema)
+                                                     table_name, schema, **kw)
         constraints = [c for c in constraints if c.contype == 'u']
         uniques = defaultdict(lambda: defaultdict(dict))
         for con in constraints:


### PR DESCRIPTION
## Todos
- [x] MIT compatible
- [x] Tests
- [x] Documentation
- [x] Updated CHANGES.rst

Addresses https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/issues/101

Existing tests already exercise this reflection code, so I don't think additional tests are necessary. Also no documentation changes other than adding a note in the changelog.