### PR TITLE
Fix Insert/Update/Delete CTEs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# IntelliJ
+.idea/

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -1,9 +1,26 @@
-from sqlalchemy import func, select
 from sqlalchemy_redshift.dialect import RedshiftDialect
+import sqlalchemy as sa
 
 
 def test_func_now():
     dialect = RedshiftDialect()
-    s = select([func.NOW().label("time")])
+    s = sa.select([sa.func.NOW().label("time")])
     compiled = s.compile(dialect=dialect)
     assert str(compiled) == "SELECT SYSDATE AS time"
+
+
+def test_insert_cte():
+    dialect = RedshiftDialect()
+    table = sa.Table(
+        'test_table',
+        sa.MetaData(),
+        sa.Column('test_column', sa.String()))
+    cte = sa.select([sa.text('1 as num')]).cte('test_cte')
+    query = sa.select([sa.column('num')]).select_from(cte)
+    insert = table.insert().from_select(['test_column'], query)
+    compiled = insert.compile(dialect=dialect)
+    assert str(compiled) == (
+        "INSERT INTO test_table (test_column) WITH test_cte AS \n"
+        "(SELECT 1 as num)\n"
+        " SELECT num \n"
+        "FROM test_cte")


### PR DESCRIPTION
So this patch fixes the fact that redshift wants cte's on inserts [after the insert](http://stackoverflow.com/questions/34852711/redshift-insert-into-table-from-cte) (which seems to [conflict with the pg grammar](https://github.com/postgres/postgres/blob/master/src/backend/parser/gram.y#L9694) but whatever amzn). This effectively fixes the behavior noted [here](https://bitbucket.org/zzzeek/sqlalchemy/issues/2551/apparently-inserts-and-update-delete-can#comment-29580233). Notably this changed in sa 1.1.0 from the cte's simply being absent (as is the case in the version depped by this lib) to them being in the wrong position (as in the latest version of sa for which I originally authored this patch). In both cases however this patch appears to function correctly.

## Todos
- [x] MIT compatible
- [x] Tests (if a little lame lols)
- [ ] Documentation
- [ ] Updated CHANGES.rst

