### PR TITLE
Add Support for CREATE TABLE AS statements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@
   (`Issue #101 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/issues/101>`_)
 - Support BZIP2 compression in COPY command
   (`Issue #110 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/issues/110>`_)
+- Support CREATE TABLE AS statements
+  (`Issue #113 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/113>`_)
 
 
 0.5.0 (2016-04-21)

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -13,7 +13,7 @@ from sqlalchemy.sql.expression import (
 )
 from sqlalchemy.types import VARCHAR, NullType
 
-from .commands import CopyCommand, UnloadFromSelect
+from .commands import CopyCommand, UnloadFromSelect, CreateTableAs
 from .compat import string_types
 
 try:
@@ -27,7 +27,8 @@ else:
     class RedshiftImpl(postgresql.PostgresqlImpl):
         __dialect__ = 'redshift'
 
-__all__ = ['CopyCommand', 'UnloadFromSelect', 'RedshiftDialect']
+__all__ = ['CopyCommand', 'UnloadFromSelect',
+           'RedshiftDialect', 'CreateTableAs']
 
 
 # Regex for parsing and identity constraint out of adsrc, e.g.:

--- a/tests/test_create_table_as.py
+++ b/tests/test_create_table_as.py
@@ -1,0 +1,144 @@
+import pytest
+import sqlalchemy as sa
+
+from sqlalchemy_redshift import dialect
+
+from rs_sqla_test_utils.utils import clean, compile_query
+
+
+EXAMPLE_QUERY = sa.select(['a', 'b']).select_from('table')
+
+
+def test_basic_create_table_as():
+    """Tests bare CreateTableAs works."""
+    create = dialect.CreateTableAs('name', EXAMPLE_QUERY)
+
+    expected_result = """
+        CREATE TABLE name
+        AS
+        SELECT a, b FROM table
+    """
+
+    assert clean(compile_query(create)) == clean(expected_result)
+
+
+def test_create_table_as_with_keys():
+    """Tests CreateTableAs with dist & sort keys works."""
+    create = dialect.CreateTableAs('name', EXAMPLE_QUERY,
+                                   diststyle='KEY', distkey='a', sortkey='b')
+
+    expected_result = """
+        CREATE TABLE name
+        DISTSTYLE KEY
+        DISTKEY (a)
+        SORTKEY (b)
+        AS
+        SELECT a, b FROM table
+    """
+
+    assert clean(compile_query(create)) == clean(expected_result)
+
+
+def test_create_table_as_with_interleaved_sort_keys():
+    """Tests CreateTableAs with interleaved sort keys works."""
+    create = dialect.CreateTableAs('name', EXAMPLE_QUERY,
+                                   sortkey=('a', 'b'),
+                                   sortkey_type='INTERLEAVED')
+
+    expected_result = """
+        CREATE TABLE name
+        INTERLEAVED SORTKEY (a,b)
+        AS
+        SELECT a, b FROM table
+    """
+
+    assert clean(compile_query(create)) == clean(expected_result)
+
+
+def test_create_table_as_with_sa_column():
+    """Ensure we can pass sa.Column objects for keys."""
+    create = dialect.CreateTableAs('name', EXAMPLE_QUERY,
+                                   diststyle='KEY',
+                                   distkey=sa.Column('a'),
+                                   sortkey=sa.Column('b'))
+
+    expected_result = """
+        CREATE TABLE name
+        DISTSTYLE KEY
+        DISTKEY (a)
+        SORTKEY (b)
+        AS
+        SELECT a, b FROM table
+    """
+
+    assert clean(compile_query(create)) == clean(expected_result)
+
+
+def test_create_table_as_with_column_names():
+    """Test CreateTableAs with custom column names."""
+    create = dialect.CreateTableAs('name', EXAMPLE_QUERY,
+                                   columns=['c', sa.Column('d')])
+
+    expected_result = """
+        CREATE TABLE name
+        (c,d)
+        AS
+        SELECT a, b FROM table
+    """
+    assert clean(compile_query(create)) == clean(expected_result)
+
+
+def test_create_table_no_backup():
+    """Test CreateTableAs with disabled backups."""
+    create = dialect.CreateTableAs('name', EXAMPLE_QUERY, backup=False)
+
+    expected_result = """
+        CREATE TABLE name
+        BACKUP NO
+        AS
+        SELECT a, b FROM table
+    """
+    assert clean(compile_query(create)) == clean(expected_result)
+
+
+def test_create_table_as_temp():
+    """Test creating temp tables in CreateTableAs."""
+    create = dialect.CreateTableAs(
+        'name', EXAMPLE_QUERY, temporary=True)
+    expected_result = """
+        CREATE TEMPORARY TABLE name
+        AS
+        SELECT a, b FROM table
+    """
+    assert clean(compile_query(create)) == clean(expected_result)
+
+
+def test_create_table_as_quoting():
+    """Test that we quote columns in CreateTableAs."""
+    create = dialect.CreateTableAs('table', EXAMPLE_QUERY,
+                                   schema='case',
+                                   columns=['union'],
+                                   distkey='select',
+                                   sortkey='table')
+
+    expected_result = """
+        CREATE TABLE "case"."table"
+        ("union")
+        DISTKEY ("select")
+        SORTKEY ("table")
+        AS
+        SELECT a, b FROM table
+    """
+    assert clean(compile_query(create)) == clean(expected_result)
+
+
+def test_create_table_as_illegal_styles():
+    """Tests CreateTableAs does not accept bad dist or sort styles."""
+    with pytest.raises(ValueError):
+        dialect.CreateTableAs('name', EXAMPLE_QUERY,
+                              sortkey=('a', 'b'),
+                              sortkey_type='ILLEGAL')
+
+    with pytest.raises(ValueError):
+        dialect.CreateTableAs('name', EXAMPLE_QUERY,
+                              diststyle='ALSO ILLEGAl')


### PR DESCRIPTION
## Todos
- [x] MIT compatible
- [x] Tests
- [x] Documentation
- [x] Updated CHANGES.rst

Adds support for Redshift's CREATE TABLE AS statement
http://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_TABLE_AS.html

I wasn't sure if something like
```python
import sqlalchemy_redshift.dialect

create = (dialect.create_table_as(name, query)
          .distkey('col')
          .sortkey('another_col'))
```
would be a little more sql-alchemy-y, but I was trying to stay between the lines of the UNLOAD and COPY statements provided by the package.