### PR TITLE
Allow tests to tolerate new default column encodings in Redshift

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@
   (`Issue #101 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/issues/101>`_)
 - Support BZIP2 compression in COPY command
   (`Issue #110 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/issues/110>`_)
+- Allow tests to tolerate new default column encodings in Redshift
+  (`Issue #114 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/114>`_)
 
 
 0.5.0 (2016-04-21)

--- a/tests/rs_sqla_test_utils/utils.py
+++ b/tests/rs_sqla_test_utils/utils.py
@@ -5,7 +5,8 @@ from sqlalchemy_redshift import dialect
 
 
 def clean(query):
-    return re.sub(r'\s+', ' ', query).strip()
+    encodings_removed = re.sub(r'\s+ENCODE\s+\w+', '', query)
+    return re.sub(r'\s+', ' ', encodings_removed).strip()
 
 
 def compile_query(q):


### PR DESCRIPTION
In order to get a new release out the door, we need to get tests passing.

Looks like Redshift changed the behavior for default encodings. Previously, all columns were RAW by default. Now, encoding is chosen per column type as discussed in http://docs.aws.amazon.com/redshift/latest/dg/c_Compression_encodings.html

I'll be pushing changes to this branch as I work.

# Todos
- [x] MIT compatible
- [x] Tests
- [ ] Documentation
- [x] Updated CHANGES.rst
