### PR TITLE
Do not include external schemas in search_path

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,8 @@
 0.6.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Do not enumerate `search_path` with external schemas (`Issue #120
+  <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/120>`_)
 
 
 0.6.0 (2017-05-04)

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -689,10 +689,11 @@ class RedshiftDialect(PGDialect_psycopg2):
             # replace the original value for search_path.
             schema_names = ['"%s"' % r.name for r in cc.execute("""
             SELECT nspname AS "name"
-            FROM pg_catalog.pg_namespace n, pg_external_schema e
+            FROM pg_catalog.pg_namespace n
             WHERE nspname !~ '^pg_'
                 AND nspname <> 'information_schema'
-                AND n.oid != e.esoid
+                AND n.oid NOT IN
+                  (SELECT esoid FROM pg_catalog.pg_external_schema)
             ORDER BY 1
             """)]
             modified_search_path = ','.join(schema_names)

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -689,8 +689,10 @@ class RedshiftDialect(PGDialect_psycopg2):
             # replace the original value for search_path.
             schema_names = ['"%s"' % r.name for r in cc.execute("""
             SELECT nspname AS "name"
-            FROM pg_catalog.pg_namespace
-            WHERE nspname !~ '^pg_' AND nspname <> 'information_schema'
+            FROM pg_catalog.pg_namespace n, pg_external_schema e
+            WHERE nspname !~ '^pg_'
+                AND nspname <> 'information_schema'
+                AND n.oid != e.esoid
             ORDER BY 1
             """)]
             modified_search_path = ','.join(schema_names)


### PR DESCRIPTION
- http://docs.aws.amazon.com/redshift/latest/dg/r_search_path.html

Amazon's new Redshift Spectrum makes use of external schemas but you cannot set the `search_path` to include external schemas which breaks reflection. This prevents any external schemas from being added to the `search_path`.

## Todos
- [x] MIT compatible
- [ ] Tests
- [ ] Documentation
- [x] Updated CHANGES.rst
