### PR TITLE
Use Enums for Format, Compression and Encoding

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@
 - Do not enumerate `search_path` with external schemas (`Issue #120
   <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/120>`_)
 - Return constraint name from get_pk_constraint and get_foreign_keys
+- Use Enums for Format, Compression and Encoding.
+  Deprecate string parameters for these parameter types
+  (`Issue #133 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/133>`_)
 
 
 0.6.0 (2017-05-04)

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,9 @@ setup(
          # version 0.9.2
         'SQLAlchemy>=0.9.2',
     ],
+    extras_require={
+        ':python_version < "3.4"': 'enum34 >= 1.1.6, < 2.0.0'
+    },
     classifiers=[
         "Development Status :: 4 - Beta",
         "Environment :: Console",

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -15,7 +15,9 @@ from sqlalchemy.sql.expression import (
 )
 from sqlalchemy.types import VARCHAR, NullType
 
-from .commands import CopyCommand, UnloadFromSelect
+from .commands import (
+    CopyCommand, UnloadFromSelect, Format, Compression, Encoding
+)
 from .compat import string_types
 
 try:
@@ -29,7 +31,10 @@ else:
     class RedshiftImpl(postgresql.PostgresqlImpl):
         __dialect__ = 'redshift'
 
-__all__ = ['CopyCommand', 'UnloadFromSelect', 'RedshiftDialect']
+__all__ = [
+    'CopyCommand', 'UnloadFromSelect', 'RedshiftDialect', 'Compression',
+    'Encoding', 'Format',
+]
 
 
 # Regex for parsing and identity constraint out of adsrc, e.g.:

--- a/tests/test_copy_command.py
+++ b/tests/test_copy_command.py
@@ -234,5 +234,19 @@ def test_different_tables():
             data_location='s3://bucket',
             access_key_id=access_key_id,
             secret_access_key=secret_access_key,
-            format='CSV'
+            format=dialect.Format.csv,
+        )
+
+
+def test_legacy_string_format():
+    metdata = sa.MetaData()
+    t1 = sa.Table('t1', metdata, sa.Column('col1', sa.Unicode()))
+    t2 = sa.Table('t2', metdata, sa.Column('col1', sa.Unicode()))
+    with pytest.raises(ValueError):
+        dialect.CopyCommand(
+            [t1.c.col1, t2.c.col1],
+            data_location='s3://bucket',
+            access_key_id=access_key_id,
+            secret_access_key=secret_access_key,
+            format='CSV',
         )


### PR DESCRIPTION
This way:

* `format="CSV"` is deprecated, to be dropped at next major version.
* `format="csv"` is not supported and never will be.
* `format=Format.csv` is the preferred style.