### PR TITLE
Require enum34 explicitly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,10 +21,8 @@ setup(
          # requires sqlalchemy.sql.base.DialectKWArgs.dialect_options, new in
          # version 0.9.2
         'SQLAlchemy>=0.9.2',
+        'enum34<2.0.0'
     ],
-    extras_require={
-        ':python_version < "3.4"': 'enum34 >= 1.1.6, < 2.0.0'
-    },
     classifiers=[
         "Development Status :: 4 - Beta",
         "Environment :: Console",


### PR DESCRIPTION
I doubt anyone cares, but this is the only way I can get it to work in our ancient version of setuptools.