### PR TITLE
Avoid manipulating search path in table metadata fetch

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,8 @@
 
 - Update tests to adapt to changes in Redshift and SQLAlchemy
   (`Issue #140 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/140>`_)
-
+- Avoid manipulating search path in table metadata fetch by using system table tables
+  directly (`Issue #147 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/147>`_)
 
 0.7.1 (2018-01-17)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,7 @@
   (`Issue #151 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/150>`_)
 - Add official support for Python 3.7
   (`Issue #153 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/153>`_)
-- Avoid manipulating search path in table metadata fetch by using system table tables
+- Avoid manipulating search path in table metadata fetch by using system tables
   directly (`Issue #147 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/147>`_)
 
 0.7.1 (2018-01-17)


### PR DESCRIPTION
We've run into some issues with transactions and the way that `_get_all_column_info` manipulates the search path. The search path manipulation only appears to be necessary because `pg_table_def` is used-- but `pg_table_def` is a pretty simple view that we can integrate into the query, minus its pesky search path filter.

For reference, `pg_table_def` is defined on Redshift as follows:

```sql
CREATE OR REPLACE VIEW pg_catalog.pg_table_def AS
SELECT n.nspname AS schemaname, c.relname AS tablename, a.attname AS "column", format_type(a.atttypid, a.atttypmod) AS "type", format_encoding(a.attencodingtype::integer) AS "encoding", a.attisdistkey AS "distkey", a.attsortkeyord AS "sortkey", a.attnotnull AS "notnull"
FROM pg_namespace n, pg_class c, pg_attribute a
WHERE n.oid = c.relnamespace AND c.oid = a.attrelid AND a.attnum > 0 AND NOT a.attisdropped AND pg_table_is_visible(c.oid)
ORDER BY n.nspname, c.relname, a.attnum
```

`pg_table_is_visible` is the bit that limits to tables in the search path.

## Todos
- [x] MIT compatible
- [ ] Tests
- [ ] Documentation
- [x] Updated CHANGES.rst
