### PR TITLE
sqlalchemy converts + to .

### DIFF
--- a/sqlalchemy_redshift/__init__.py
+++ b/sqlalchemy_redshift/__init__.py
@@ -6,5 +6,5 @@ from sqlalchemy.dialects import registry
 
 registry.register("redshift", "sqlalchemy_redshift.dialect", "RedshiftDialect")
 registry.register(
-    "redshift+psycopg2", "sqlalchemy_redshift.dialect", "RedshiftDialect"
+    "redshift.psycopg2", "sqlalchemy_redshift.dialect", "RedshiftDialect"
 )


### PR DESCRIPTION
SQLAlchemy converts + to . when looking up the entrypoint from the registry: https://github.com/zzzeek/sqlalchemy/blob/master/lib/sqlalchemy/engine/url.py#L155

This will also match what is found in setup.py.

