### PR TITLE
Add COPY command support for Parquet and ORC

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,6 @@
   (`Issue #140 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/140>`_)
 - Add support for Parquet and ORC file formats in the COPY command
   (`Issue #151 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/150>`_)
-- Add official support for Python 3.7
 
 
 0.7.1 (2018-01-17)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,9 @@
 
 - Update tests to adapt to changes in Redshift and SQLAlchemy
   (`Issue #140 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/140>`_)
+- Add support for Parquet and ORC file formats in the COPY command
+  (`Issue #151 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/150>`_)
+- Add official support for Python 3.7
 
 
 0.7.1 (2018-01-17)

--- a/sqlalchemy_redshift/commands.py
+++ b/sqlalchemy_redshift/commands.py
@@ -5,6 +5,7 @@ import re
 import warnings
 
 import sqlalchemy as sa
+from sqlalchemy import exc as sa_exc
 from sqlalchemy.ext import compiler as sa_compiler
 from sqlalchemy.sql import expression as sa_expression
 
@@ -267,6 +268,9 @@ class Format(enum.Enum):
     csv = 'CSV'
     json = 'JSON'
     avro = 'AVRO'
+    orc = 'ORC'
+    parquet = 'PARQUET'
+    fixed_width = 'FIXEDWIDTH'
 
 
 class Compression(enum.Enum):
@@ -551,6 +555,13 @@ def visit_copy_command(element, compiler, **kw):
             value=element.path_file,
             type_=sa.String,
         ))
+    elif element.format == Format.orc:
+        format_ = 'FORMAT AS ORC'
+    elif element.format == Format.parquet:
+        format_ = 'FORMAT AS PARQUET'
+    elif element.format == Format.fixed_width and element.fixed_width is None:
+        raise sa_exc.CompileError(
+            "'fixed_width' argument required for format 'FIXEDWIDTH'.")
     else:
         format_ = ''
 

--- a/sqlalchemy_redshift/commands.py
+++ b/sqlalchemy_redshift/commands.py
@@ -315,7 +315,7 @@ class CopyCommand(_ExecutableClause):
     quote : str, optional
         Specifies the character to be used as the quote character when using
         ``format=Format.csv``. The default is a double quotation mark ( ``"`` )
-    delimiter : File delimiter, optional
+    delimiter : Field delimiter, optional
         defaults to ``|``
     path_file : str, optional
         Specifies an Amazon S3 location to a JSONPaths file to explicitly map

--- a/tests/test_copy_command.py
+++ b/tests/test_copy_command.py
@@ -2,6 +2,7 @@ import pytest
 import sqlalchemy as sa
 
 from sqlalchemy_redshift import dialect
+from sqlalchemy_redshift import commands
 from rs_sqla_test_utils.utils import clean, compile_query
 
 access_key_id = 'IO1IWSZL5YRFM3BEW256'
@@ -97,6 +98,26 @@ def test_format():
         ignore_header=0,
         empty_as_null=True,
         blanks_as_null=True,
+    )
+    assert clean(expected_result) == clean(compile_query(copy))
+
+
+@pytest.mark.parametrize('format_type', (
+    commands.Format.orc,
+    commands.Format.parquet,
+))
+def test_format__columnar(format_type):
+    expected_result = """
+    COPY t1 FROM 's3://mybucket/data/listing/'
+    WITH CREDENTIALS AS '%s'
+    FORMAT AS %s
+    """ % (creds, format_type.value.upper())
+    copy = dialect.CopyCommand(
+        tbl2,
+        data_location='s3://mybucket/data/listing/',
+        access_key_id=access_key_id,
+        secret_access_key=secret_access_key,
+        format=format_type,
     )
     assert clean(expected_result) == clean(compile_query(copy))
 

--- a/tests/test_copy_command.py
+++ b/tests/test_copy_command.py
@@ -1,5 +1,6 @@
 import pytest
 import sqlalchemy as sa
+from sqlalchemy import exc as sa_exc
 
 from sqlalchemy_redshift import dialect
 from sqlalchemy_redshift import commands
@@ -132,6 +133,19 @@ def test_invalid_format():
             secret_access_key=secret_access_key,
             format=';drop table bobby_tables;'
         )
+
+
+def test_fixed_width_format_without_widths():
+    copy = dialect.CopyCommand(
+        tbl,
+        format=commands.Format.fixed_width,
+        data_location='s3://bucket',
+        access_key_id=access_key_id,
+        secret_access_key=secret_access_key
+    )
+    with pytest.raises(sa_exc.CompileError,
+                       match=r"^'fixed_width' argument required.*$"):
+        compile_query(copy)
 
 
 def test_compression():


### PR DESCRIPTION
Closes #151 

* Allow choosing Parquet and ORC as load formats (see [here](https://docs.aws.amazon.com/redshift/latest/dg/copy-parameters-data-format.html)).
* Allow choosing fixed_width as a load format as well for consistency with the others. Enforce the presence of the field widths argument if `Formats.fixed_width` is selected.

## Todos
- [x] MIT compatible
- [x] Tests
- [x] Documentation
- [x] Updated CHANGES.rst
