### PR TITLE
Fixes reflection for tables from schemas which are not in current user's `search_path`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@
 
 - Update tests to adapt to changes in Redshift and SQLAlchemy
   (`Issue #140 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/140>`_)
+- Fix reflection of tables from schemas which are not in current user's search_path.
+  (`Issue #145 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/145>`_)
 
 
 0.7.1 (2018-01-17)

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -707,9 +707,8 @@ class RedshiftDialect(PGDialect_psycopg2):
             ORDER BY 1
             """)]
             modified_search_path = ','.join(schema_names)
-            cc.execute("SET LOCAL search_path TO %s" % modified_search_path)
-
             result = cc.execute("""
+            SET LOCAL search_path TO %s;
             SELECT
               n.nspname as "schema",
               c.relname as "table_name",
@@ -731,12 +730,10 @@ class RedshiftDialect(PGDialect_psycopg2):
               ON (att.attrelid, att.attnum) = (ad.adrelid, ad.adnum)
             WHERE n.nspname !~ '^pg_'
             ORDER BY n.nspname, c.relname, att.attnum
-            """)
+            """ % modified_search_path)
             for col in result:
                 key = RelationKey(col.table_name, col.schema, connection)
                 all_columns[key].append(col)
-
-            cc.execute("SET LOCAL search_path TO %s" % search_path)
 
         return dict(all_columns)
 


### PR DESCRIPTION
Set local search_path value within the same statement passed to execute so that it has effect for the subsequent select.

This addresses #145 and is related to #64 

## Todos
- [x] MIT compatible
- [x] Tests (tested against real Redshift)
- [x] Documentation (not relevant)
- [x] Updated CHANGES.rst
