### PR TITLE
Officially support 3.7, run Tox with same version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,21 @@
 sudo: false
 language: python
-python: "3.6"
+python:
+  - "2.7"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+  - "3.7-dev"   # Change to "3.7" once Travis gets 3.7.0 on their machines
 
 env:
-  matrix:
-    - TOXENV=py27
-    - TOXENV=py34
-    - TOXENV=py36
-    - TOXENV=lint
   global:
     - secure: g/ta2yudfA55ruxd+GHxYQUd39OM/hoEhNp0KgPm3QINaXwaB6C9eQ31qOi/i9OiSjmVwISE+yUaPtQP2jtbYnkS/SHiRNvzhfA+mPrT0n0hoVSNIlxl94E8hoPBZr2jlYVQ6dIuT98mIRYJu/wiGHDQCuar6znpiKFB1/gyUszvZxAxHJIe5EcjuXWFnre91b96tNkZRKJZv+Jst0CkknVcKAZ4kmC/o5Z1hr5VaMekRV5SKf+vMEfVc+W9VktqDBgKwaFIwWqSgQFk5LOnPr/EZq8mrqPpa+LFaLiQpDGDAdaVEM0/A3dzx3YnYoBFNr5hmCtoCLWccxC+diaw3kZuTX6olxn8cbRCVf8lu4JuJKFU5CgTLS7NBH3Rpk4iRE7C9v4W+QKjw3CJxLCMoMqQCbYx6GjzjZYbZBA6jvaS6ZFe41N6egA0SpNvKtfYU9TR7lNVwGehRIY9kycOEX5ZQInkqILxz5YHrkMNfICdLY+rYFBDvgNAOZxYR1tLaOG9jYuUbBOLVRZz78wkPrXynquay6HZn7AxBxOdnvGQAkINvo40Lx/MWdZ88o3f/th838cpPCxBRQZ5Kn3RkHNhGHwUJadsbaOLnKrj3ISaTOvq0brA1mxJFyJwoVrn+rFs80CWRonQ5lQeaOHf0p1flH7j+TFhl/INkvXsf7Y=  # PGPASSWORD
 
 matrix:
   include:
-    - python: "3.5"
-      env: TOXENV=py35
+    - python: "3.6"
+      env: TOXENV=lint
 
-install: pip install tox
+install: pip install tox tox-travis
 script: tox
 cache: pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 sudo: false
 language: python
 python:
@@ -5,7 +6,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  - "3.7-dev"   # Change to "3.7" once Travis gets 3.7.0 on their machines
+  - "3.7"
 
 env:
   global:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@
 
 - Update tests to adapt to changes in Redshift and SQLAlchemy
   (`Issue #140 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/140>`_)
+- Add official support for Python 3.7
 
 
 0.7.1 (2018-01-17)

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
     url='https://github.com/sqlalchemy-redshift/sqlalchemy-redshift',
     packages=['sqlalchemy_redshift', 'redshift_sqlalchemy'],
     package_data={'sqlalchemy_redshift': ['redshift-ca-bundle.crt']},
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     install_requires=[
         'psycopg2>=2.5',
          # requires sqlalchemy.sql.base.DialectKWArgs.dialect_options, new in
@@ -38,6 +39,7 @@ setup(
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
     entry_points={
         'sqlalchemy.dialects': [

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35,36}, lint, docs
+envlist = py{27,34,35,36,37}, lint, docs
 
 [testenv]
 passenv = PGPASSWORD

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ deps =
     requests==2.7.0
     psycopg2==2.7.3.2
     sqlalchemy==1.2.0
-    pytest==2.8.2
+    pytest==3.10.1
     alembic==0.7.6
 
 [testenv:lint]


### PR DESCRIPTION
## Todos
- [x] MIT compatible
- [x] Tests
- [x] Documentation
- [x] Updated CHANGES.rst


* Add official Python 3.7 support.
* Add a `python_requires` restriction in `setup.py` so `pip` will refuse to install the package on unsupported versions.
* Run `tox` on the same Python version as the environment it's testing. This helps reduce the number of variables to consider when something *really* weird happens like [this bug](https://github.com/pypa/setuptools/issues/1042) in `setuptools`.