### PR TITLE
Add info support for late binding views

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,6 @@
 0.7.4 (unreleased)
 ------------------
-
-- Nothing changed yet.
-
+- Add support for column info on redshift late binding views
 
 0.7.3 (2019-01-16)
 ------------------

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -689,7 +689,7 @@ class RedshiftDialect(PGDialect_psycopg2):
         all_columns = defaultdict(list)
         with connection.contextual_connect() as cc:
             result = cc.execute("""
-SELECT
+            SELECT
               n.nspname as "schema",
               c.relname as "table_name",
               att.attname as "name",
@@ -715,26 +715,26 @@ SELECT
               AND NOT att.attisdropped
             UNION
             SELECT
-			  view_schema as "schema",
-		      view_name as "table_name",
-			  col_name as "name",
-			  null as "encode",
-		      col_type as "type",
-			  null as "distkey",
-			  0 as "sortkey",
-			  null as "notnull",
-			  null as "adsrc",
-			  null as "attmum",
-			  col_type as "format_type",
-			  null as "default",
-			  null as "schema_oid",
-			  null as "table_oid"
-        FROM pg_get_late_binding_view_cols() cols(
-          view_schema name,
-                 view_name name,
-                 col_name name,
-                 col_type varchar,
-                 col_num int)
+	      view_schema as "schema",
+	      view_name as "table_name",
+	      col_name as "name",
+	      null as "encode",
+	      col_type as "type",
+	      null as "distkey",
+	      0 as "sortkey",
+	      null as "notnull",
+	      null as "adsrc",
+	      null as "attmum",
+	      col_type as "format_type",
+	      null as "default",
+	      null as "schema_oid",
+	      null as "table_oid"
+            FROM pg_get_late_binding_view_cols() cols(
+              view_schema name,
+              view_name name,
+              col_name name,
+              col_type varchar,
+              col_num int)
             ORDER BY "schema", "table_name", "attnum";
             """)
             for col in result:

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -724,7 +724,7 @@ class RedshiftDialect(PGDialect_psycopg2):
               0 as "sortkey",
               null as "notnull",
               null as "adsrc",
-              null as "attmum",
+              null as "attnum",
               col_type as "format_type",
               null as "default",
               null as "schema_oid",

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -689,7 +689,7 @@ class RedshiftDialect(PGDialect_psycopg2):
         all_columns = defaultdict(list)
         with connection.contextual_connect() as cc:
             result = cc.execute("""
-            SELECT
+SELECT
               n.nspname as "schema",
               c.relname as "table_name",
               att.attname as "name",
@@ -713,7 +713,29 @@ class RedshiftDialect(PGDialect_psycopg2):
             WHERE n.nspname !~ '^pg_'
               AND att.attnum > 0
               AND NOT att.attisdropped
-            ORDER BY n.nspname, c.relname, att.attnum
+            UNION
+            SELECT
+			  view_schema as "schema",
+		      view_name as "table_name",
+			  col_name as "name",
+			  null as "encode",
+		      col_type as "type",
+			  null as "distkey",
+			  0 as "sortkey",
+			  null as "notnull",
+			  null as "adsrc",
+			  null as "attmum",
+			  col_type as "format_type",
+			  null as "default",
+			  null as "schema_oid",
+			  null as "table_oid"
+        FROM pg_get_late_binding_view_cols() cols(
+          view_schema name,
+                 view_name name,
+                 col_name name,
+                 col_type varchar,
+                 col_num int)
+            ORDER BY "schema", "table_name", "attnum";
             """)
             for col in result:
                 key = RelationKey(col.table_name, col.schema, connection)

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -715,20 +715,20 @@ class RedshiftDialect(PGDialect_psycopg2):
               AND NOT att.attisdropped
             UNION
             SELECT
-	      view_schema as "schema",
-	      view_name as "table_name",
-	      col_name as "name",
-	      null as "encode",
-	      col_type as "type",
-	      null as "distkey",
-	      0 as "sortkey",
-	      null as "notnull",
-	      null as "adsrc",
-	      null as "attmum",
-	      col_type as "format_type",
-	      null as "default",
-	      null as "schema_oid",
-	      null as "table_oid"
+              view_schema as "schema",
+              view_name as "table_name",
+              col_name as "name",
+              null as "encode",
+              col_type as "type",
+              null as "distkey",
+              0 as "sortkey",
+              null as "notnull",
+              null as "adsrc",
+              null as "attmum",
+              col_type as "format_type",
+              null as "default",
+              null as "schema_oid",
+              null as "table_oid"
             FROM pg_get_late_binding_view_cols() cols(
               view_schema name,
               view_name name,


### PR DESCRIPTION
## Todos
- [x] MIT compatible
- [x] Tests
- [x] Documentation
- [x] Updated CHANGES.rst

Small change to the _get_all_column_info sql to enable column information for late binding views. Tested against our redshift with late binding views over normal and external tables. Resolves this issue https://github.com/apache/incubator-superset/issues/4435