### PR TITLE
Add MAXFILESIZE argument to UNLOAD

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 0.7.4 (unreleased)
 ------------------
 - Add support for column info on redshift late binding views
+- Add support for ``MAXFILESIZE`` argument to ``UNLOAD``.
+  (`Issue #123 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/issues/123>`_)
 
 0.7.3 (2019-01-16)
 ------------------

--- a/tests/test_unload_from_select.py
+++ b/tests/test_unload_from_select.py
@@ -89,6 +89,7 @@ def test_all_redshift_options():
         allow_overwrite=True,
         parallel=False,
         region='us-west-2',
+        max_file_size=10 * 1024**2,
     )
 
     expected_result = """
@@ -106,6 +107,7 @@ def test_all_redshift_options():
         ALLOWOVERWRITE
         PARALLEL OFF
         REGION 'us-west-2'
+        MAXFILESIZE 10.0 MB
     """.format(creds=creds)
 
     assert clean(compile_query(unload)) == clean(expected_result)
@@ -129,7 +131,8 @@ def test_all_redshift_options_with_header():
         escape=True,
         allow_overwrite=True,
         parallel=False,
-        region='ap-northeast-2'
+        region='ap-northeast-2',
+        max_file_size=10 * 1024 ** 2,
     )
 
     expected_result = """
@@ -147,6 +150,7 @@ def test_all_redshift_options_with_header():
         ALLOWOVERWRITE
         PARALLEL OFF
         REGION 'ap-northeast-2'
+        MAXFILESIZE 10.0 MB
     """.format(creds=creds)
 
     assert clean(compile_query(unload)) == clean(expected_result)


### PR DESCRIPTION
Closes #123.

Sorry to bother you all, but this would be a useful addition for my team.  I tried to have this PR follow what was discussed in the related issue (#123). 

A couple things I'm not sure about here:
* I whether it was worth adding validation around the upper and lower limits that redshift has for MAXFILESIZE (5 MB, 6.24 GB).
* The value appears to be interpreted as fractional MiB, but Redshift seems to round to the nearest KiB (I ran a test unload with `max_file_size=10_000_000` bytes and got a bunch of files a few hundred bytes larger than a million bytes). I put a note in the docstring, but perhaps there's a better way of addressing it.  I didn't see mention of this in the Redshift docs.


## Todos
- [x] MIT compatible
- [x] Tests
- [x] Documentation
- [x] Updated CHANGES.rst
