### PR TITLE
Switch to column keyword arguments

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,7 @@
 0.7.4 (unreleased)
 ------------------
+
+- Switch from info to keyword arguments on columns for SQLAlchemy >= 1.3.0
 - Add support for column info on redshift late binding views
 - Add support for ``MAXFILESIZE`` argument to ``UNLOAD``.
   (`Issue #123 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/issues/123>`_)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@
 ------------------
 
 - Switch from info to keyword arguments on columns for SQLAlchemy >= 1.3.0
+   (`Issue #161 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/161>`_)
 - Add support for column info on redshift late binding views
 - Add support for ``MAXFILESIZE`` argument to ``UNLOAD``.
   (`Issue #123 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/issues/123>`_)

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -258,7 +258,7 @@ class RedshiftDDLCompiler(PGDDLCompiler):
     ...     sa.Column('id', sa.Integer, primary_key=True),
     ...     sa.Column('name', sa.String, info={'encode': 'lzo'})
     ... )
-    >>> print(CreateTable(productproduct_pre_1_3_0).compile(engine))
+    >>> print(CreateTable(product_pre_1_3_0).compile(engine))
     <BLANKLINE>
     CREATE TABLE product_pre_1_3_0 (
         id INTEGER NOT NULL,

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -252,15 +252,15 @@ class RedshiftDDLCompiler(PGDDLCompiler):
     as keyword arguments is not supported on the column level.
     Instead, column info dictionary can be used.
 
-    >>> product = sa.Table(
-    ...     'product',
+    >>> product_pre_1_3_0 = sa.Table(
+    ...     'product_pre_1_3_0',
     ...     metadata,
     ...     sa.Column('id', sa.Integer, primary_key=True),
     ...     sa.Column('name', sa.String, info={'encode': 'lzo'})
     ... )
-    >>> print(CreateTable(product).compile(engine))
+    >>> print(CreateTable(productproduct_pre_1_3_0).compile(engine))
     <BLANKLINE>
-    CREATE TABLE product (
+    CREATE TABLE product_pre_1_3_0 (
         id INTEGER NOT NULL,
         name VARCHAR ENCODE lzo,
         PRIMARY KEY (id)

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -250,7 +250,7 @@ class RedshiftDDLCompiler(PGDDLCompiler):
 
     For SQLAlchemy versions < 1.3.0, passing Redshift dialect options
     as keyword arguments is not supported on the column level.
-    Instead, column info dictionary can be used.
+    Instead, a column info dictionary can be used:
 
     >>> product_pre_1_3_0 = sa.Table(
     ...     'product_pre_1_3_0',

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -258,15 +258,6 @@ class RedshiftDDLCompiler(PGDDLCompiler):
     ...     sa.Column('id', sa.Integer, primary_key=True),
     ...     sa.Column('name', sa.String, info={'encode': 'lzo'})
     ... )
-    >>> print(CreateTable(product_pre_1_3_0).compile(engine))
-    <BLANKLINE>
-    CREATE TABLE product_pre_1_3_0 (
-        id INTEGER NOT NULL,
-        name VARCHAR ENCODE lzo,
-        PRIMARY KEY (id)
-    )
-    <BLANKLINE>
-    <BLANKLINE>
 
     We can also specify the distkey and sortkey options:
 

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -26,6 +26,7 @@ except ImportError:
     pass
 else:
     from alembic.ddl.base import RenameTable
+
     compiles(RenameTable, 'redshift')(postgresql.visit_rename_table)
 
     class RedshiftImpl(postgresql.PostgresqlImpl):
@@ -35,7 +36,6 @@ __all__ = [
     'CopyCommand', 'UnloadFromSelect', 'RedshiftDialect', 'Compression',
     'Encoding', 'Format',
 ]
-
 
 # Regex for parsing and identity constraint out of adsrc, e.g.:
 #   "identity"(445178, 0, '1,1'::text)
@@ -229,7 +229,8 @@ class RedshiftDDLCompiler(PGDDLCompiler):
     <BLANKLINE>
 
     Column-level special syntax can also be applied using Redshift dialect
-    specific keyword arguments. For example, we can specify the ENCODE for a column:
+    specific keyword arguments.
+    For example, we can specify the ENCODE for a column:
 
     >>> product = sa.Table(
     ...     'product',
@@ -254,7 +255,9 @@ class RedshiftDDLCompiler(PGDDLCompiler):
     ...     metadata,
     ...     sa.Column('id', sa.Integer, primary_key=True),
     ...     sa.Column(
-    ...         'name', sa.String, redshift_distkey=True, redshift_sortkey=True
+    ...         'name', sa.String,
+    ...         redshift_distkey=True,
+    ...         redshift_sortkey=True
     ...     )
     ... )
     >>> print(CreateTable(sku).compile(engine))
@@ -552,11 +555,13 @@ class RedshiftDialect(PGDialect_psycopg2):
         Overrides interface
         :meth:`~sqlalchemy.engine.Inspector.get_table_options`.
         """
+
         def keyfunc(column):
             num = int(column.sortkey)
             # If sortkey is interleaved, column numbers alternate
             # negative values, so take abs.
             return abs(num)
+
         table = self._get_redshift_relation(connection, table_name,
                                             schema, **kw)
         columns = self._get_redshift_columns(connection, table_name,

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -235,7 +235,7 @@ class RedshiftDDLCompiler(PGDDLCompiler):
     ...     'product',
     ...     metadata,
     ...     sa.Column('id', sa.Integer, primary_key=True),
-    ...     sa.Column('name', sa.String, redshift_encode='lzo'})
+    ...     sa.Column('name', sa.String, redshift_encode='lzo')
     ... )
     >>> print(CreateTable(product).compile(engine))
     <BLANKLINE>
@@ -254,7 +254,7 @@ class RedshiftDDLCompiler(PGDDLCompiler):
     ...     metadata,
     ...     sa.Column('id', sa.Integer, primary_key=True),
     ...     sa.Column(
-    ...         'name', sa.String, redshift_distkey=True, redshift_sortkey=True}
+    ...         'name', sa.String, redshift_distkey=True, redshift_sortkey=True
     ...     )
     ... )
     >>> print(CreateTable(sku).compile(engine))

--- a/tests/rs_sqla_test_utils/models.py
+++ b/tests/rs_sqla_test_utils/models.py
@@ -4,7 +4,6 @@ from sqlalchemy import event
 from sqlalchemy.ext import declarative
 from sqlalchemy.schema import CreateSchema
 
-
 Base = declarative.declarative_base()
 event.listen(Base.metadata, 'before_create', CreateSchema('other_schema'))
 
@@ -217,7 +216,8 @@ class ReflectionDelimitedTableNoSchema(Base):
 class Referenced(Base):
     __tablename__ = 'referenced'
     id = sa.Column(
-        sa.Integer(), primary_key=True, nullable=False, redshift_identity= (1, 1)
+        sa.Integer(), primary_key=True, nullable=False,
+        redshift_identity=(1, 1)
     )
     __table_args__ = {
         'redshift_diststyle': 'EVEN',

--- a/tests/rs_sqla_test_utils/models.py
+++ b/tests/rs_sqla_test_utils/models.py
@@ -4,6 +4,7 @@ from sqlalchemy import event
 from sqlalchemy.ext import declarative
 from sqlalchemy.schema import CreateSchema
 
+
 Base = declarative.declarative_base()
 event.listen(Base.metadata, 'before_create', CreateSchema('other_schema'))
 

--- a/tests/rs_sqla_test_utils/models.py
+++ b/tests/rs_sqla_test_utils/models.py
@@ -13,7 +13,7 @@ class Basic(Base):
     __tablename__ = 'basic'
     name = sa.Column(
         sa.Unicode(64), primary_key=True,
-        info={'distkey': True, 'sortkey': True, 'encode': 'lzo'}
+        redshift_distkey=True, redshift_sortkey=True, redshift_encode='lzo'
     )
 
 
@@ -156,7 +156,7 @@ class ReflectionDefaultValue(Base):
 class ReflectionIdentity(Base):
     __tablename__ = 'reflection_identity'
     col1 = sa.Column(sa.Integer(), primary_key=True)
-    col2 = sa.Column(sa.Integer(), info={'identity': (1, 3)})
+    col2 = sa.Column(sa.Integer(), redshift_identity=(1, 3))
     col3 = sa.Column(sa.Integer())
     __table_args__ = (
         {'redshift_diststyle': 'EVEN'}
@@ -217,10 +217,7 @@ class ReflectionDelimitedTableNoSchema(Base):
 class Referenced(Base):
     __tablename__ = 'referenced'
     id = sa.Column(
-        sa.Integer(), primary_key=True, nullable=False,
-        info={
-            'identity': (1, 1),
-        }
+        sa.Integer(), primary_key=True, nullable=False, redshift_identity= (1, 1)
     )
     __table_args__ = {
         'redshift_diststyle': 'EVEN',

--- a/tests/test_ddl_compiler.py
+++ b/tests/test_ddl_compiler.py
@@ -45,7 +45,7 @@ class TestDDLCompiler(object):
         table = Table(
             't1',
             MetaData(),
-            Column('id', Integer, primary_key=True, info={'identity': [1, 2]}),
+            Column('id', Integer, primary_key=True, redshift_identity=[1, 2]),
             Column('name', String),
         )
 
@@ -192,7 +192,7 @@ class TestDDLCompiler(object):
         table = Table('t1',
                       MetaData(),
                       Column('id', Integer, primary_key=True,
-                             info=dict(sortkey=True)),
+                             redshift_sortkey=True),
                       Column('name', String)
                       )
 
@@ -210,7 +210,7 @@ class TestDDLCompiler(object):
         table = Table('t1',
                       MetaData(),
                       Column('id', Integer, primary_key=True,
-                             info=dict(distkey=True)),
+                             redshift_distkey=True),
                       Column('name', String)
                       )
 
@@ -228,7 +228,7 @@ class TestDDLCompiler(object):
         table = Table('t1',
                       MetaData(),
                       Column('id', Integer, primary_key=True,
-                             info=dict(encode="LZO")),
+                             redshift_encode="LZO"),
                       Column('name', String)
                       )
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ commands = py.test {posargs}
 deps =
     requests==2.7.0
     psycopg2==2.7.3.2
-    sqlalchemy==1.2.0
+    sqlalchemy==1.3.0
     pytest==3.10.1
     alembic==0.7.6
 


### PR DESCRIPTION
* Switch from `info` to dialect specific kwargs, which are now supported in SQLAlchemy>=1.3.0, as per recommendation from the author: https://bitbucket.org/zzzeek/alembic/pull-requests/86/add-support-for-column-info/diff
* existing `info` support for SQLAlchemy < 1.3.0 and minimal SQLAlchemy version retained
* tests updated to use  SQLAlchemy 1.3.0

## Todos
- [X] MIT compatible
- [X] Tests
- [X] Documentation
- [X] Updated CHANGES.rst
