### PR TITLE
Add support for ALTER TABLE ... APPEND FROM

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,11 @@
   (`Issue #123 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/issues/123>`_)
 - Add support for the `CREATE LIBRARY`_ command.
   (`Issue #124 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/issues/124>`_)
+- Add support for the `ALTER TABLE APPEND`_ command.
+  (`Issue #162 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/162>`_)
 
 .. _CREATE LIBRARY: https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_LIBRARY.html
+.. _ALTER TABLE APPEND: https://docs.aws.amazon.com/redshift/latest/dg/r_ALTER_TABLE_APPEND.html
 
 
 0.7.3 (2019-01-16)

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -17,7 +17,7 @@ from sqlalchemy.types import VARCHAR, NullType
 
 from .commands import (
     CopyCommand, UnloadFromSelect, Format, Compression, Encoding,
-    CreateLibraryCommand,
+    CreateLibraryCommand, AlterTableAppendCommand,
 )
 from .compat import string_types
 
@@ -34,7 +34,7 @@ else:
 
 __all__ = [
     'CopyCommand', 'UnloadFromSelect', 'RedshiftDialect', 'Compression',
-    'Encoding', 'Format', 'CreateLibraryCommand',
+    'Encoding', 'Format', 'CreateLibraryCommand', 'AlterTableAppendCommand',
 ]
 
 

--- a/tests/test_alter_table.py
+++ b/tests/test_alter_table.py
@@ -1,0 +1,30 @@
+import pytest
+import sqlalchemy as sa
+
+from sqlalchemy_redshift import dialect
+
+from rs_sqla_test_utils.utils import clean, compile_query
+
+
+@pytest.mark.parametrize('kwargs,expected_query', (
+    ({}, 'ALTER TABLE trg APPEND FROM src'),
+    ({'fill_target': True}, 'ALTER TABLE trg APPEND FROM src FILLTARGET'),
+    ({'ignore_extra': True}, 'ALTER TABLE trg APPEND FROM src IGNOREEXTRA'),
+))
+def test_append__basic(kwargs, expected_query):
+    source = sa.Table('src', sa.MetaData(), sa.Column('value', sa.Integer))
+    target = sa.Table('trg', sa.MetaData(), sa.Column('value', sa.Integer))
+    command = dialect.AlterTableAppendCommand(source, target, **kwargs)
+    assert clean(compile_query(command)) == clean(expected_query)
+
+
+def test_append__ignoreextra_and_filltarget():
+    source = sa.Table('src', sa.MetaData(), sa.Column('value', sa.Integer))
+    target = sa.Table('trg', sa.MetaData(), sa.Column('value', sa.Integer))
+
+    with pytest.raises(
+        ValueError, match='"ignore_extra" cannot be used with "fill_target".'
+    ):
+        dialect.AlterTableAppendCommand(
+            source, target, fill_target=True, ignore_extra=True
+        )


### PR DESCRIPTION
Adds a command for Redshift's [`ALTER TABLE APPEND`](https://docs.aws.amazon.com/redshift/latest/dg/r_ALTER_TABLE_APPEND.html)

## Todos
- [x] MIT compatible
- [x] Tests
- [x] Documentation
- [x] Updated CHANGES.rst
