### PR TITLE
Add preliminary support for reflection of Spectrum tables/columns.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 0.7.4 (unreleased)
 ------------------
 
+- Add support for reflection of spectrum tables.
+  (`Issue #122 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/issues/122>`_)
 - Switch from info to keyword arguments on columns for ``SQLAlchemy >= 1.3.0``
   (`Issue #161 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/161>`_)
 - Add support for column info on redshift late binding views

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -761,6 +761,38 @@ class RedshiftDialect(PGDialect_psycopg2):
               col_name name,
               col_type varchar,
               col_num int)
+            UNION
+            SELECT schemaname AS "schema",
+               tablename AS "table_name",
+               columnname AS "name",
+               null AS "encode",
+               -- Spectrum represents data types differently.
+               -- Standardize, so we can infer types.
+               CASE
+                 WHEN external_type = 'int' THEN 'integer'
+                 ELSE
+                   replace(
+                    replace(external_type, 'decimal', 'numeric'),
+                    'varchar', 'character varying')
+                 END
+                    AS "type",
+               null AS "distkey",
+               0 AS "sortkey",
+               null AS "notnull",
+               null AS "adsrc",
+               null AS "attnum",
+               CASE
+                 WHEN external_type = 'int' THEN 'integer'
+                 ELSE
+                   replace(
+                    replace(external_type, 'decimal', 'numeric'),
+                    'varchar', 'character varying')
+                 END
+                    AS "format_type",
+               null AS "default",
+               null AS "schema_oid",
+               null AS "table_oid"
+            FROM svv_external_columns
             ORDER BY "schema", "table_name", "attnum";
             """)
             for col in result:

--- a/tests/test_reflection_views.py
+++ b/tests/test_reflection_views.py
@@ -42,7 +42,7 @@ def test_late_binding_view_reflection(redshift_engine):
     assert(len(view.columns) == 2)
 
 
-def test_late_binding_view_reflection(redshift_engine):
+def test_spectrum_reflection(redshift_engine):
     table_ddl = """create external table spectrum.sales(
         salesid integer,
         listid integer,

--- a/tests/test_reflection_views.py
+++ b/tests/test_reflection_views.py
@@ -40,3 +40,25 @@ def test_late_binding_view_reflection(redshift_engine):
     view = Table('my_late_view', MetaData(),
                  autoload=True, autoload_with=redshift_engine)
     assert(len(view.columns) == 2)
+
+
+def test_late_binding_view_reflection(redshift_engine):
+    table_ddl = """create external table spectrum.sales(
+        salesid integer,
+        listid integer,
+        sellerid integer,
+        pricepaid decimal(8,2),
+        saletime timestamp)
+        row format delimited
+        fields terminated by '\t'
+        stored as textfile
+        location 's3://awssampledbuswest2/tickit/spectrum/sales/'
+        table properties ('numRows'='172000');
+    """
+    conn = redshift_engine.connect()
+    conn.execute(table_ddl)
+    insp = inspect(redshift_engine)
+    table_definition = insp.get_columns('sales', schema='spectrum')
+
+    assert 'sales_id' in table_definition.columns
+    assert 'pricepaid' in table_definition.columns


### PR DESCRIPTION
Redshift Spectrum allows you to create tables that scan objects on S3.
This allows you to infer data types from the table.

Partially addresses #122.

## Todos
- [x] MIT compatible
- [x] Tests
- [x] Documentation
- [x] Updated CHANGES.rst
