### PR TITLE
Check the version of any of the supported Psycopg2 packages

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,8 @@
 0.7.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Extend psycopg2 package version check to also support psycopg2-binary and psycopg2cffi
+  (`Issue #178 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/178>`_)
 
 
 0.7.4 (2019-10-08)

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,8 @@ setup(
     package_data={'sqlalchemy_redshift': ['redshift-ca-bundle.crt']},
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     install_requires=[
+        # requires sqlalchemy.sql.base.DialectKWArgs.dialect_options, new in
+        # version 0.9.2
         'SQLAlchemy>=0.9.2,<2.0.0',
     ],
     extras_require={

--- a/sqlalchemy_redshift/__init__.py
+++ b/sqlalchemy_redshift/__init__.py
@@ -7,7 +7,7 @@ except ImportError:
         'No module named psycopg2. Please install either '
         'psycopg2 or psycopg2-binary package for CPython '
         'or psycopg2cffi for Pypy.'
-    ) from None
+    )
 
 for package in ['psycopg2', 'psycopg2-binary', 'psycopg2cffi']:
     try:

--- a/sqlalchemy_redshift/__init__.py
+++ b/sqlalchemy_redshift/__init__.py
@@ -1,14 +1,27 @@
-from pkg_resources import get_distribution, parse_version
+from pkg_resources import DistributionNotFound, get_distribution, parse_version
 
 try:
     import psycopg2  # noqa: F401
-    if get_distribution('psycopg2').parsed_version < parse_version('2.5'):
-        raise ImportError('Minimum required version for psycopg2 is 2.5')
 except ImportError:
     raise ImportError(
         'No module named psycopg2. Please install either '
         'psycopg2 or psycopg2-binary package for CPython '
         'or psycopg2cffi for Pypy.'
+    ) from None
+
+for package in ['psycopg2', 'psycopg2-binary', 'psycopg2cffi']:
+    try:
+        if get_distribution(package).parsed_version < parse_version('2.5'):
+            raise ImportError('Minimum required version for psycopg2 is 2.5')
+        break
+    except DistributionNotFound:
+        pass
+else:
+    raise ImportError(
+        'A module was found named psycopg2, '
+        'but the version of it could not be checked '
+        'as it was neither the Python package psycopg2, '
+        'psycopg2-binary or psycopg2cffi.'
     )
 
 __version__ = get_distribution('sqlalchemy-redshift').version

--- a/sqlalchemy_redshift/__init__.py
+++ b/sqlalchemy_redshift/__init__.py
@@ -16,13 +16,6 @@ for package in ['psycopg2', 'psycopg2-binary', 'psycopg2cffi']:
         break
     except DistributionNotFound:
         pass
-else:
-    raise ImportError(
-        'A module was found named psycopg2, '
-        'but the version of it could not be checked '
-        'as it was neither the Python package psycopg2, '
-        'psycopg2-binary or psycopg2cffi.'
-    )
 
 __version__ = get_distribution('sqlalchemy-redshift').version
 

--- a/sqlalchemy_redshift/__init__.py
+++ b/sqlalchemy_redshift/__init__.py
@@ -4,8 +4,6 @@ try:
     import psycopg2  # noqa: F401
     if get_distribution('psycopg2').parsed_version < parse_version('2.5'):
         raise ImportError('Minimum required version for psycopg2 is 2.5')
-        # requires sqlalchemy.sql.base.DialectKWArgs.dialect_options, new in
-        # version 0.9.2
 except ImportError:
     raise ImportError(
         'No module named psycopg2. Please install either '


### PR DESCRIPTION
A check was introduced in commit 8e0c4857a1c08f257b95d3b1ee5f6eb795d55cdc which
would check what version of the 'psycopg2' Python (pip) package was installed
as the dependency was removed from setup.py.

The check would however only check the 'psycopg2' package and not the other two
supported providers of the psycopg2 module, which meant importing the
sqlalchemy_redshift module would throw an exception, even though they were
installed.

This changes the check to check for either of the three supported psycopg2
packages and throws an exception if any of them fail to validate.

I've also moved a comment back to `setup.py` about the required SQLAlchemy
version, which seemed to have been moved inadvertently in the same commit.

## Todos
- [x] MIT compatible
- [ ] Tests
- [ ] Documentation
- [x] Updated CHANGES.rst
