### PR TITLE
Add support for Parquet format in UNLOAD command

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,8 @@
 0.7.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add support for Parquet format in ``UNLOAD`` command
+  (`Issue #187 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/issues/187>`_)
 
 
 0.7.6 (2020-01-17)

--- a/sqlalchemy_redshift/commands.py
+++ b/sqlalchemy_redshift/commands.py
@@ -307,8 +307,18 @@ def visit_unload_from_select(element, compiler, **kw):
         if el.delimiter is not None or el.fixed_width is not None:
             raise ValueError(
                 'CSV format cannot be used with delimiter or fixed_width')
+    elif el.format == Format.parquet:
+        format_ = 'FORMAT AS {}'.format(el.format.value)
+        if any((
+            el.delimiter, el.fixed_width, el.add_quotes, el.escape, el.null,
+            el.header, el.gzip
+        )):
+            raise ValueError(
+                'Parquet format cannot be used with `delimiter`, `fixed_width`,'
+                ' `add_quotes`, `escape`, `null_as`, `header`, or `gzip`.'
+            )
     else:
-        raise ValueError('Only CSV format is currently supported')
+        raise ValueError('Only CSV and Parquet formats are currently supported')
 
     qs = template.format(
         manifest='MANIFEST' if el.manifest else '',

--- a/sqlalchemy_redshift/commands.py
+++ b/sqlalchemy_redshift/commands.py
@@ -314,11 +314,13 @@ def visit_unload_from_select(element, compiler, **kw):
             el.header, el.gzip
         )):
             raise ValueError(
-                'Parquet format cannot be used with `delimiter`, `fixed_width`,'
-                ' `add_quotes`, `escape`, `null_as`, `header`, or `gzip`.'
+                "Parquet format can't be used with `delimiter`, `fixed_width`,"
+                ' `add_quotes`, `escape`, `null`, `header`, or `gzip`.'
             )
     else:
-        raise ValueError('Only CSV and Parquet formats are currently supported')
+        raise ValueError(
+            'Only CSV and Parquet formats are currently supported.'
+        )
 
     qs = template.format(
         manifest='MANIFEST' if el.manifest else '',

--- a/tests/test_unload_from_select.py
+++ b/tests/test_unload_from_select.py
@@ -231,7 +231,7 @@ def test_parquet_format__basic():
     {'header': True},
 ))
 def test_parquet_format__bad_options_crash(kwargs):
-    """Verify we crash if we try to use the Parquet format with a bad option."""
+    """Verify we crash if we use the Parquet format with a bad option."""
     unload = dialect.UnloadFromSelect(
         select=sa.select([sa.func.count(table.c.id)]),
         unload_location='s3://bucket/key',


### PR DESCRIPTION
* Closes #187
* Added additional tests to unload command in CSV format to ensure it crashes if passed invalid arguments.

## Todos
- [x] MIT compatible
- [x] Tests
- [x] Documentation
- [x] Updated CHANGES.rst
