### PR TITLE
Import ABC from collections.abc instead of collections for Python 3.9 compatibility

### DIFF
--- a/sqlalchemy_redshift/commands.py
+++ b/sqlalchemy_redshift/commands.py
@@ -1,8 +1,11 @@
-import collections
 import enum
 import numbers
 import re
 import warnings
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 
 import sqlalchemy as sa
 from sqlalchemy import exc as sa_exc
@@ -581,7 +584,7 @@ class CopyCommand(_ExecutableClause):
 
         table = None
         columns = []
-        if isinstance(to, collections.Iterable):
+        if isinstance(to, Iterable):
             for column in to:
                 if table is not None and table != column.table:
                     raise ValueError(


### PR DESCRIPTION
## Todos

- [x] MIT compatible
- [ ] Tests
- [ ] Documentation
- [ ] Updated CHANGES.rst

Fixes #189 . I am not sure if it's CHANGELOG worth. Please let me know if I need to update it. 
