### PR TITLE
Adding Support for IAM-based Authorization.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
         # requires sqlalchemy.sql.base.DialectKWArgs.dialect_options, new in
         # version 0.9.2
         'SQLAlchemy>=0.9.2,<2.0.0',
+        'boto3>=1.11.0',
     ],
     extras_require={
         ':python_version < "3.4"': 'enum34 >= 1.1.6, < 2.0.0'

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -429,6 +429,7 @@ class RedshiftDialect(PGDialect_psycopg2):
 
     name = 'redshift'
     max_identifier_length = 127
+    iam_argument = 'iam'
 
     statement_compiler = RedshiftCompiler
     ddl_compiler = RedshiftDDLCompiler
@@ -641,9 +642,58 @@ class RedshiftDialect(PGDialect_psycopg2):
             'redshift_interleaved_sortkey': interleaved_sortkey,
         }
 
+    def _do_generate_iam_auth_token(self, redshift, cparams):
+        # Hostname is the cluster identifier
+        cluster_id = cparams['host']
+        response = redshift.describe_clusters(ClusterIdentifier=cluster_id)
+        # If there is no cluster, it will throw an exception
+        rs_cluster = response['Clusters'][0]
+
+        response = redshift.get_cluster_credentials(
+            DbUser=cparams['user'],
+            DbName=cparams['database'],
+            ClusterIdentifier=cluster_id,
+            AutoCreate=False
+        )
+
+        # Extract user, password, hostname, and port from the response
+        return {
+            'host' : rs_cluster['Endpoint']['Address'],
+            'port' : rs_cluster['Endpoint']['Port'],
+            'user' : response['DbUser'],
+            'password' : response['DbPassword'],
+            'database' : cparams['database']
+        }
+
+    def _generate_iam_auth_token(self, cparams):
+        """
+        Parses for necessary information to generate username and
+        password using the necessary Redshift API.
+
+        Username and database are passed to the get_cluster_credentials()
+        API to verify permissions.
+        """
+        try:
+            import boto3
+            redshift = boto3.client('redshift')
+
+            # Verify that the parameters make sense.
+            if "password" in cparams:
+                raise ValueError("'password' cannot be used when connecting with IAM federation.")
+
+            return self._do_generate_iam_auth_token(redshift, cparams)
+
+        except ImportError:
+            raise ImportError("Could not find boto3 library, make sure the dependency is installed.")
+
+
     def create_connect_args(self, *args, **kwargs):
         """
         Build DB-API compatible connection arguments.
+
+        In addition, since Redshift offers different authentication
+        mechanisms, we use this method to dynamically retrieve
+        credentials via IAM, if the "iam" parameter is present.
 
         Overrides interface
         :meth:`~sqlalchemy.engine.interfaces.Dialect.create_connect_args`.
@@ -658,6 +708,11 @@ class RedshiftDialect(PGDialect_psycopg2):
         cargs, cparams = super(RedshiftDialect, self).create_connect_args(
             *args, **kwargs
         )
+
+        if self.iam_argument in cparams:
+            cparams.update(self._generate_iam_auth_token(cparams))
+            del cparams[self.iam_argument]
+
         default_args.update(cparams)
         return cargs, default_args
 

--- a/tests/test_iam_auth.py
+++ b/tests/test_iam_auth.py
@@ -1,0 +1,71 @@
+from botocore.stub import Stubber
+
+import boto3
+import pytest
+import sqlalchemy as sa
+import sqlalchemy.engine.url as _url
+
+
+@pytest.fixture(autouse=True)
+def redshift_mock():
+    client = boto3.client("redshift")
+    return [client, Stubber(client)]
+
+
+def prepare_stub(stubber, user, db, cluster_id, endpoint_dns, port):
+    stubber.deactivate()
+    response = {"Clusters": [{"Endpoint": {"Address": endpoint_dns, "Port": port}}]}
+    stubber.add_response("describe_clusters", response)
+
+    stubber.add_response(
+        "get_cluster_credentials",
+        {"DbUser": "IAM:{}".format(user), "DbPassword": "randompassword"},
+        {
+            "DbUser": user,
+            "DbName": db,
+            "ClusterIdentifier": cluster_id,
+            "AutoCreate": False,
+        },
+    )
+    stubber.activate()
+
+
+def test_url_transformations(redshift_mock):
+    redshift, stubber = redshift_mock
+
+    # Create a test engine
+    engine = sa.create_engine("redshift+psycopg2://test")
+
+    basic_url = _url.make_url("redshift://the_user@clusterid/the_database?iam=true")
+    args = basic_url.translate_connect_args(username="user")
+    assert args["host"] == "clusterid"
+    assert not "password" in args
+
+    prepare_stub(
+        stubber,
+        args["user"],
+        cluster_id=args["host"],
+        db=args["database"],
+        endpoint_dns="full.dns",
+        port=8192,
+    )
+    cparams = engine.dialect._do_generate_iam_auth_token(redshift, args)
+
+    assert cparams["user"] == "IAM:the_user"
+    assert cparams["host"] == "full.dns"
+    assert cparams["password"] == "randompassword"
+    assert cparams["database"] == args["database"]
+
+
+def test_invalid_parameters():
+    engine = sa.create_engine("redshift+psycopg2://test")
+
+    # Passwords are not allowed when using IAM, but can be used when IAM is not used
+    with pytest.raises(ValueError):
+        basic_url = _url.make_url(
+            "redshift://the_user:password@clusterid/the_database?iam=true"
+        )
+        engine.dialect.create_connect_args(basic_url)
+
+    basic_url = _url.make_url("redshift://the_user:password@clusterid/the_database")
+    assert engine.dialect.create_connect_args(basic_url) is not None

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ deps =
     sqlalchemy==1.3.0
     pytest==3.10.1
     alembic==0.7.6
+    boto3==1.12.11
 
 [testenv:lint]
 deps =


### PR DESCRIPTION
This patch adds support to dynamically generate passwords
necessary to access Redshift by using the Redshfit API
GetClusterCredentials().

https://docs.aws.amazon.com/redshift/latest/APIReference/API_GetClusterCredentials.html

It intercepts the extraction of the connection arguments, if the
new additional `iam` parameter is present. It expects the
hostname parameter of the URL to be the actual cluster identifier
and will use this to lookup the DNS name and port configuration.
In addition, it updates the username and password with the
updated values retrieved from the API call.

It expects the URL for the engine to be of the following structure:

    redshift://user@cluster_identifier/database?iam=true

Testing:

This patch adds two new unit tests for parsing the URL and extracting
the correct parameters from the API calls. It adds boto3 to the Tox
dependencies for mock testing.

## Todos
- [ ] MIT compatible
- [x] Tests
- [ ] Documentation
- [ ] Updated CHANGES.rst
