### PR TITLE
Adding Support for IAM-based Authorization.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
         # requires sqlalchemy.sql.base.DialectKWArgs.dialect_options, new in
         # version 0.9.2
         'SQLAlchemy>=0.9.2,<2.0.0',
+        'boto3>=1.11.0',
     ],
     extras_require={
         ':python_version < "3.4"': 'enum34 >= 1.1.6, < 2.0.0'

--- a/tests/test_iam_auth.py
+++ b/tests/test_iam_auth.py
@@ -1,0 +1,86 @@
+from botocore.stub import Stubber
+
+import boto3
+import pytest
+import sqlalchemy as sa
+import sqlalchemy.engine.url as _url
+
+
+@pytest.fixture(autouse=True)
+def redshift_mock():
+    client = boto3.client("redshift", region_name="us-east-1")
+    return [client, Stubber(client)]
+
+
+def prepare_stub(stubber, user, db, cluster_id, endpoint_dns, port):
+    stubber.deactivate()
+    response = {
+        "Clusters": [{"Endpoint": {"Address": endpoint_dns, "Port": port}}]
+    }
+    stubber.add_response("describe_clusters", response)
+
+    stubber.add_response(
+        "get_cluster_credentials",
+        {"DbUser": "IAM:{}".format(user), "DbPassword": "randompassword"},
+        {
+            "DbUser": user,
+            "DbName": db,
+            "ClusterIdentifier": cluster_id,
+            "AutoCreate": False,
+        },
+    )
+    stubber.activate()
+
+
+def test_url_transformations(redshift_mock):
+    redshift, stubber = redshift_mock
+
+    # Create a test engine
+    engine = sa.create_engine("redshift+psycopg2://test")
+
+    basic_url = _url.make_url(
+        "redshift://the_user@clusterid/"
+        "the_database?iam=true&aws-region=us-east-1"
+    )
+    args = basic_url.translate_connect_args(username="user")
+    assert args["host"] == "clusterid"
+    assert "password" not in args
+
+    prepare_stub(
+        stubber,
+        args["user"],
+        cluster_id=args["host"],
+        db=args["database"],
+        endpoint_dns="full.dns",
+        port=8192,
+    )
+    cparams = engine.dialect._do_generate_iam_auth_token(redshift, args)
+
+    assert cparams["user"] == "IAM:the_user"
+    assert cparams["host"] == "full.dns"
+    assert cparams["password"] == "randompassword"
+    assert cparams["database"] == args["database"]
+
+
+def test_invalid_parameters():
+    engine = sa.create_engine("redshift+psycopg2://test")
+
+    # Passwords are not allowed when using IAM, but can be
+    # used when IAM is not used
+    with pytest.raises(ValueError):
+        basic_url = _url.make_url(
+            "redshift://the_user:password@clusterid/"
+            "the_database?iam=true&aws-region=us-east-1"
+        )
+        engine.dialect.create_connect_args(basic_url)
+
+    with pytest.raises(ValueError):
+        basic_url = _url.make_url(
+            "redshift://the_user@clusterid/the_database?iam=true"
+        )
+        engine.dialect.create_connect_args(basic_url)
+
+    basic_url = _url.make_url(
+        "redshift://the_user:password@clusterid/the_database"
+    )
+    assert engine.dialect.create_connect_args(basic_url) is not None

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ deps =
     sqlalchemy==1.3.0
     pytest==3.10.1
     alembic==0.7.6
+    boto3==1.12.11
 
 [testenv:lint]
 deps =


### PR DESCRIPTION
This patch adds support to dynamically generate passwords
necessary to access Redshift by using the Redshfit API
GetClusterCredentials().

https://docs.aws.amazon.com/redshift/latest/APIReference/API_GetClusterCredentials.html

It intercepts the extraction of the connection arguments, if the
new additional `iam` parameter is present. It expects the
hostname parameter of the URL to be the actual cluster identifier
and will use this to lookup the DNS name and port configuration.
In addition, it updates the username and password with the
updated values retrieved from the API call.

It expects the URL for the engine to be of the following structure:

    redshift://user@cluster_identifier/database?iam=true

Testing:

This patch adds two new unit tests for parsing the URL and extracting
the correct parameters from the API calls. It adds boto3 to the Tox
dependencies for mock testing.

## Todos
- [ ] MIT compatible
- [ ] Tests
- [ ] Documentation
- [ ] Updated CHANGES.rst
