### PR TITLE
Add generated support

### DIFF
--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -820,9 +820,7 @@ class RedshiftDialect(PGDialect_psycopg2):
               col_type varchar,
               col_num int)
             ORDER BY "schema", "table_name", "attnum";
-            """
-            % generated
-            )
+            """ % generated)
             for col in result:
                 key = RelationKey(col.table_name, col.schema, connection)
                 all_columns[key].append(col)

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -760,9 +760,9 @@ class RedshiftDialect(PGDialect_psycopg2):
         all_columns = defaultdict(list)
 
         generated = (
-            "a.attgenerated as generated"
+            "att.attgenerated as generated"
             if self.server_version_info >= (12,)
-            else "NULL as generated"
+            else "null as generated"
         )
 
         with connection.contextual_connect() as cc:


### PR DESCRIPTION
Added in logic for _get_all_column_info during reflection similar to how sqlalchemy updated their code in the commit below to deal with generated columns added in postgress 12.   Not sure how to update tests, since this feature isn't available in Redshift

https://github.com/sqlalchemy/sqlalchemy/commit/62b7dace0c1d03acf3224085d03a03684a969031#diff-d33159d80d3deef1d5bdcd057dcc3d6b