### PR TITLE
Fix reflection of unique constraints

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,8 @@
 0.7.8 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix reflection of unique constraints
+  (`Issue #199 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/199>`_)
 
 
 0.7.7 (2020-02-02)

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -601,7 +601,7 @@ class RedshiftDialect(PGDialect_psycopg2):
             uniques[con.conname]["cols"][con.attnum] = con.attname
 
         return [
-            {'name': None,
+            {'name': name,
              'column_names': [uc["cols"][i] for i in uc["key"]]}
             for name, uc in uniques.items()
         ]


### PR DESCRIPTION
I noticed this because `alembic revision --autogenerate` was inserting a bunch of `op.create_unique_constraint` calls in revision scripts, even when the constraints in question already exist in the database.

## Todos
- [x] MIT compatible
- [x] Tests | N/A?
- [x] Documentation | N/A?
- [x] Updated CHANGES.rst
