### PR TITLE
Materialized Views for `sqlalchemy-redshift`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,9 +1,3 @@
-0.7.9 (unreleased)
-------------------
-
-- Added support for materialized views
-  (`AWS Docs <https://docs.aws.amazon.com/redshift/latest/dg/materialized-view-overview.html`_)
-
 0.7.8 (unreleased)
 ------------------
 
@@ -11,6 +5,8 @@
   (`Issue #199 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/199>`_)
 - Support for altering column comments in Alembic migrations
   (`Issue #191 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/issues/191>`_)
+- Added support for materialized views
+  (`AWS Docs <https://docs.aws.amazon.com/redshift/latest/dg/materialized-view-overview.html`_)
 
 0.7.7 (2020-02-02)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+0.7.9 (unreleased)
+------------------
+
+- Added support for materialized views
+  (`AWS Docs <https://docs.aws.amazon.com/redshift/latest/dg/materialized-view-overview.html`_)
+
 0.7.8 (unreleased)
 ------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,7 @@ Contents:
    ddl-compiler
    dialect
    commands
+   ddl
 
 Indices and tables
 ==================

--- a/sqlalchemy_redshift/commands.py
+++ b/sqlalchemy_redshift/commands.py
@@ -943,9 +943,9 @@ class RefreshMaterializedView(_ExecutableClause):
     is up to date.
 
     >>> import sqlalchemy as sa
-    >>> from sqlalchemy_redshift.commands import RefereshMaterializedView
+    >>> from sqlalchemy_redshift.commands import RefreshMaterializedView
     >>> engine = sa.create_engine('redshift+psycopg2://example')
-    >>> refresh = RefereshMaterializedView('materialized_view_of_users')
+    >>> refresh = RefreshMaterializedView('materialized_view_of_users')
     >>> print(refresh.compile(engine))
     <BLANKLINE>
     REFRESH MATERIALIZED VIEW materialized_view_of_users
@@ -966,7 +966,7 @@ class RefreshMaterializedView(_ExecutableClause):
         self.name = name
 
 
-@sa_compiler.compiles(RefereshMaterializedView)
+@sa_compiler.compiles(RefreshMaterializedView)
 def compile_refresh_materialized_view(element, compiler, **kw):
     """
     Formats and returns the refresh statement for materialized views.

--- a/sqlalchemy_redshift/commands.py
+++ b/sqlalchemy_redshift/commands.py
@@ -934,9 +934,15 @@ def visit_create_library_command(element, compiler, **kw):
 
 
 class RefereshMaterializedView(_ExecutableClause):
+    """Prepares a Redshift REFRESH MATERIALIZED VIEW statement.
+    SEE:
+    docs.aws.amazon.com/redshift/latest/dg/materialized-view-refresh-sql-command
+
+    Parameters
+    ----------
+    name: str, required
+        The name of the view to refresh
     """
-    """
-    #TODO document above
     def __init__(self, name):
         self.name = name
 

--- a/sqlalchemy_redshift/commands.py
+++ b/sqlalchemy_redshift/commands.py
@@ -943,7 +943,7 @@ class RefreshMaterializedView(_ExecutableClause):
     is up to date.
 
     >>> import sqlalchemy as sa
-    >>> from sqlalchemy_redshift.commands import RefreshMaterializedView
+    >>> from sqlalchemy_redshift.dialect import RefreshMaterializedView
     >>> engine = sa.create_engine('redshift+psycopg2://example')
     >>> refresh = RefreshMaterializedView('materialized_view_of_users')
     >>> print(refresh.compile(engine))

--- a/sqlalchemy_redshift/commands.py
+++ b/sqlalchemy_redshift/commands.py
@@ -934,16 +934,35 @@ def visit_create_library_command(element, compiler, **kw):
 
 
 class RefereshMaterializedView(_ExecutableClause):
-    """Prepares a Redshift REFRESH MATERIALIZED VIEW statement.
+    """
+    Prepares a Redshift REFRESH MATERIALIZED VIEW statement.
     SEE:
     docs.aws.amazon.com/redshift/latest/dg/materialized-view-refresh-sql-command
 
-    Parameters
-    ----------
-    name: str, required
-        The name of the view to refresh
+    This reruns the query underlying the view to ensure the materialized data is
+    up to date.
+
+    >>> import sqlalchemy as sa
+    >>> from sqlalchemy_redshift.commands import RefereshMaterializedView
+    >>> engine = sa.create_engine('redshift+psycopg2://example')
+    >>> refresh = RefereshMaterializedView('materialized_view_of_users')
+    >>> print(refresh.compile(engine))
+    <BLANKLINE>
+    REFRESH MATERIALIZED VIEW materialized_view_of_users
+    <BLANKLINE>
+    <BLANKLINE>
+
+    This can be included in any execute() statement.
     """
     def __init__(self, name):
+        """
+        Builds the Executable/ClauseElement that represents the refresh command.
+
+        Parameters
+        ----------
+        name: str, required
+            The name of the view to refresh
+        """
         self.name = name
 
 

--- a/sqlalchemy_redshift/commands.py
+++ b/sqlalchemy_redshift/commands.py
@@ -939,8 +939,8 @@ class RefereshMaterializedView(_ExecutableClause):
     SEE:
     docs.aws.amazon.com/redshift/latest/dg/materialized-view-refresh-sql-command
 
-    This reruns the query underlying the view to ensure the materialized data is
-    up to date.
+    This reruns the query underlying the view to ensure the materialized data
+    is up to date.
 
     >>> import sqlalchemy as sa
     >>> from sqlalchemy_redshift.commands import RefereshMaterializedView
@@ -956,7 +956,7 @@ class RefereshMaterializedView(_ExecutableClause):
     """
     def __init__(self, name):
         """
-        Builds the Executable/ClauseElement that represents the refresh command.
+        Builds the Executable/ClauseElement that represents the refresh command
 
         Parameters
         ----------

--- a/sqlalchemy_redshift/commands.py
+++ b/sqlalchemy_redshift/commands.py
@@ -931,3 +931,20 @@ def visit_create_library_command(element, compiler, **kw):
                          or_replace='OR REPLACE' if element.replace else '',
                          region='REGION :region' if element.region else '')
     return compiler.process(sa.text(query).bindparams(*bindparams), **kw)
+
+
+class RefereshMaterializedView(_ExecutableClause):
+    """
+    """
+    #TODO document above
+    def __init__(self, name):
+        self.name = name
+
+
+@sa_compiler.compiles(RefereshMaterializedView)
+def compile_drop_materialized_view(element, compiler, **kw):
+    """
+    Formats and returns the refresh statement for materialized views.
+    """
+    text = "REFRESH MATERIALIZED VIEW {name}"
+    return text.format(name=element.name)

--- a/sqlalchemy_redshift/commands.py
+++ b/sqlalchemy_redshift/commands.py
@@ -967,7 +967,7 @@ class RefereshMaterializedView(_ExecutableClause):
 
 
 @sa_compiler.compiles(RefereshMaterializedView)
-def compile_drop_materialized_view(element, compiler, **kw):
+def compile_refresh_materialized_view(element, compiler, **kw):
     """
     Formats and returns the refresh statement for materialized views.
     """

--- a/sqlalchemy_redshift/commands.py
+++ b/sqlalchemy_redshift/commands.py
@@ -933,7 +933,7 @@ def visit_create_library_command(element, compiler, **kw):
     return compiler.process(sa.text(query).bindparams(*bindparams), **kw)
 
 
-class RefereshMaterializedView(_ExecutableClause):
+class RefreshMaterializedView(_ExecutableClause):
     """
     Prepares a Redshift REFRESH MATERIALIZED VIEW statement.
     SEE:

--- a/sqlalchemy_redshift/ddl.py
+++ b/sqlalchemy_redshift/ddl.py
@@ -1,0 +1,54 @@
+import sqlalchemy as sa
+from sqlalchemy import exc as sa_exc
+from sqlalchemy.ext import compiler as sa_compiler
+from sqlalchemy.sql import expression as sa_expression
+from sqlalchemy.schema import DDLElement
+
+from .dialect import RedshiftDDLCompiler
+
+class CreateMaterializedView(DDLElement):
+    """
+    """
+    # TODO docs above
+    def __init__(self, name, selectable, backup=True, diststyle=None, 
+                 distkey=None, sortkey=None, interleaved_sortkey=None):
+        self.name = name
+        self.selectable = selectable
+        self.backup = backup
+        self.diststyle = diststyle
+        self.distkey = distkey
+        self.sortkey = sortkey
+        self.interleaved_sortkey = interleaved_sortkey
+
+@sa_compiler.compiles(CreateMaterializedView)
+def compile_create_materialized_view(element, compiler, **kw):
+    """
+    Returns the sql query that creates the materialized view
+    """
+
+    text = """
+        CREATE MATERIALIZED VIEW {name}
+        BACKUP {backup}
+        {table_attributes}
+        AS {selectable}
+    """
+
+    # TODO check element.preparer is the right type
+    table_attributes = RedshiftDDLCompiler.get_table_attributes(
+        element.preparer,
+        diststyle=element.diststyle,
+        distkey=element.distkey,
+        sortkey=element.sortkey,
+        interleaved_sortkey=element.interleaved_sortkey
+    )
+    backup = "YES" if element.backup else "NO"
+    selectable = compiler.sql_compiler.process(element.selectable,
+                                               literal_binds=True)
+
+    text = text.format(
+        name=element.name,
+        backup=backup,
+        table_attributes=table_attributes,
+        selectable=selectable
+    )
+    return compiler.process(sa.text(text), **kw)

--- a/sqlalchemy_redshift/ddl.py
+++ b/sqlalchemy_redshift/ddl.py
@@ -24,6 +24,7 @@ def get_table_attributes(preparer,
     """
     # TODO fill out above
     text = ""
+
     has_distkey = _check_if_key_exists(distkey)
     if diststyle:
         diststyle = diststyle.upper()
@@ -34,6 +35,10 @@ def get_table_attributes(preparer,
         if diststyle != 'KEY' and has_distkey:
             raise sa_exc.ArgumentError(
                 u"DISTSTYLE EVEN/ALL is not compatible with a DISTKEY."
+            )
+        if diststyle == 'KEY' and not has_distkey:
+            raise sa_exc.ArgumentError(
+                u"DISTKEY specification is required for DISTSTYLE KEY"
             )
         text += " DISTSTYLE " + diststyle
 
@@ -49,6 +54,7 @@ def get_table_attributes(preparer,
             "Parameters sortkey and interleaved_sortkey are "
             "mutually exclusive; you may not specify both."
         )
+
     if has_sortkey or has_interleaved:
         keys = sortkey if has_sortkey else interleaved_sortkey
         if isinstance(keys, (string_types, Column)):

--- a/sqlalchemy_redshift/ddl.py
+++ b/sqlalchemy_redshift/ddl.py
@@ -109,7 +109,7 @@ class CreateMaterializedView(DDLElement):
     This works for any selectable.  Consider the trivial example of this table:
 
     >>> import sqlalchemy as sa
-    >>> from sqlalchemy_redshift.ddl import CreateMaterializedView
+    >>> from sqlalchemy_redshift.dialect import CreateMaterializedView
     >>> engine = sa.create_engine('redshift+psycopg2://example')
     >>> metadata = sa.MetaData()
     >>> user = sa.Table(
@@ -219,7 +219,7 @@ class DropMaterializedView(DDLElement):
     This undoes the create command, as expected:
 
     >>> import sqlalchemy as sa
-    >>> from sqlalchemy_redshift.ddl import DropMaterializedView
+    >>> from sqlalchemy_redshift.dialect import DropMaterializedView
     >>> engine = sa.create_engine('redshift+psycopg2://example')
     >>> drop = DropMaterializedView(
     ...     'materialized_view_of_users',

--- a/sqlalchemy_redshift/ddl.py
+++ b/sqlalchemy_redshift/ddl.py
@@ -115,3 +115,21 @@ def compile_create_materialized_view(element, compiler, **kw):
         selectable=selectable
     )
     return text
+
+
+class DropMaterializedView(DDLElement):
+    """
+    """
+    def __init__(self, name, if_exists=False):
+        self.name = name
+        self.if_exists = if_exists
+
+
+@sa_compiler.compiles(DropMaterializedView)
+def compile_drop_materialized_view(element, compiler, **kw):
+    """
+    Formats and returns the drop statement for materialized views.
+    """
+    text = "DROP MATERIALIZED VIEW {if_exists}{name}"
+    if_exists = "IF EXISTS " if element.if_exists else ""
+    return text.format(if_exists=if_exists, name=element.name)

--- a/sqlalchemy_redshift/ddl.py
+++ b/sqlalchemy_redshift/ddl.py
@@ -1,4 +1,3 @@
-import sqlalchemy as sa
 from sqlalchemy import exc as sa_exc, Column
 from sqlalchemy.ext import compiler as sa_compiler
 from sqlalchemy.schema import DDLElement
@@ -120,6 +119,7 @@ def compile_create_materialized_view(element, compiler, **kw):
 class DropMaterializedView(DDLElement):
     """
     """
+    #TODO document above
     def __init__(self, name, if_exists=False):
         self.name = name
         self.if_exists = if_exists

--- a/sqlalchemy_redshift/ddl.py
+++ b/sqlalchemy_redshift/ddl.py
@@ -61,7 +61,7 @@ def get_table_attributes(preparer,
             keys = [keys]
         keys = [key.name if isinstance(key, Column) else key
                 for key in keys]
-        if interleaved_sortkey:
+        if has_interleaved:
             text += " INTERLEAVED"
         sortkey_string = ", ".join(preparer.quote(key)
                                    for key in keys)

--- a/sqlalchemy_redshift/ddl.py
+++ b/sqlalchemy_redshift/ddl.py
@@ -92,20 +92,19 @@ def compile_create_materialized_view(element, compiler, **kw):
 
     text = """
         CREATE MATERIALIZED VIEW {name}
-        BACKUP {backup}
+        {backup}
         {table_attributes}
         AS {selectable}
     """
-
-    # TODO check element.preparer is the right type
     table_attributes = get_table_attributes(
-        element.preparer,
+        compiler.preparer,
         diststyle=element.diststyle,
         distkey=element.distkey,
         sortkey=element.sortkey,
         interleaved_sortkey=element.interleaved_sortkey
     )
-    backup = "YES" if element.backup else "NO"
+    # Defaults to yes, so omit default cas3
+    backup = " " if element.backup else "BACKUP NO "
     selectable = compiler.sql_compiler.process(element.selectable,
                                                literal_binds=True)
 
@@ -115,4 +114,4 @@ def compile_create_materialized_view(element, compiler, **kw):
         table_attributes=table_attributes,
         selectable=selectable
     )
-    return compiler.process(sa.text(text), **kw)
+    return text

--- a/sqlalchemy_redshift/ddl.py
+++ b/sqlalchemy_redshift/ddl.py
@@ -1,11 +1,11 @@
-from sqlalchemy import exc as sa_exc, Column
+import sqlalchemy as sa
 from sqlalchemy.ext import compiler as sa_compiler
 from sqlalchemy.schema import DDLElement
 
 from .compat import string_types
 
 def _check_if_key_exists(key):
-    return isinstance(key, Column) or key
+    return isinstance(key, sa.Column) or key
 
 def get_table_attributes(preparer,
                          diststyle=None,
@@ -18,47 +18,75 @@ def get_table_attributes(preparer,
 
     Parameters
     ----------
-    preparer: RedshiftIdentifierPreparer
-        TODO
+    preparer: RedshiftIdentifierPreparer, required
+        The preparer associated with the compiler, usually accessed through
+        compiler.preparer.  You can use a RedshiftDDLCompiler instance to access
+        it.
+    diststyle: str, optional
+        The diststle to use for the table attributes.  This must be one of:
+        ("ALL", "EVEN", "KEY").  If unset, Redshift passes AUTO. If KEY is used,
+        a distkey argument must be provided.  Inversely, if a diststyle other
+        than KEY is provided, a distkey argument cannot be provided.
+    distkey: str or sqlalchemy.Column, optional
+        The distribution key to use the for the table attributes.  This can be
+        provided without any distsyle specified or with KEY diststyle specified.
+    sortkey: str or sqlalchemy.Column (or iterable thereof), optional
+        The (compound) sort key(s) to use for the table attributes. Mutually
+        exclusive option from interleaved_sortkey.
+    interleaved_sortkey: str or sqlalchemy.Column (or iterable thereof), optional
+        The (interleaved) sort key(s) to use for the table attributes. Mutually
+        exclusive option from sortkey.
+
+    Returns
+    -------
+    string
+        the table_attributes to append to a DDLElement, normally when creating
+        a table or materialized view.
+
+    Raises
+    ------
+    sqlalchemy.exc.ArgumentError
+        when an invalid diststyle is set,
+        when incompatable (diststyle, distkey) pairs are used,
+        when both sortkey and interleaved_sortkey is specified.
     """
-    # TODO fill out above
     text = ""
 
     has_distkey = _check_if_key_exists(distkey)
     if diststyle:
         diststyle = diststyle.upper()
         if diststyle not in ('EVEN', 'KEY', 'ALL'):
-            raise sa_exc.ArgumentError(
+            raise sa.exc.ArgumentError(
                 u"diststyle {0} is invalid".format(diststyle)
             )
         if diststyle != 'KEY' and has_distkey:
-            raise sa_exc.ArgumentError(
+            raise sa.exc.ArgumentError(
                 u"DISTSTYLE EVEN/ALL is not compatible with a DISTKEY."
             )
         if diststyle == 'KEY' and not has_distkey:
-            raise sa_exc.ArgumentError(
+            raise sa.exc.ArgumentError(
                 u"DISTKEY specification is required for DISTSTYLE KEY"
             )
         text += " DISTSTYLE " + diststyle
 
     if has_distkey:
-        if isinstance(distkey, Column):
+        if isinstance(distkey, sa.Column):
             distkey = distkey.name
         text += " DISTKEY ({0})".format(preparer.quote(distkey))
 
     has_sortkey = _check_if_key_exists(sortkey)
     has_interleaved = _check_if_key_exists(interleaved_sortkey)
     if has_sortkey and has_interleaved:
-        raise sa_exc.ArgumentError(
+        raise sa.exc.ArgumentError(
             "Parameters sortkey and interleaved_sortkey are "
             "mutually exclusive; you may not specify both."
         )
 
     if has_sortkey or has_interleaved:
         keys = sortkey if has_sortkey else interleaved_sortkey
-        if isinstance(keys, (string_types, Column)):
+        if isinstance(keys, (string_types, sa.Column)):
             keys = [keys]
-        keys = [key.name if isinstance(key, Column) else key
+        keys = [key.name if isinstance(key, sa.Column) else key
                 for key in keys]
         if has_interleaved:
             text += " INTERLEAVED"
@@ -70,10 +98,71 @@ def get_table_attributes(preparer,
 
 class CreateMaterializedView(DDLElement):
     """
+    DDLElement to create a materialized view in Redshift where the distribution
+    options can be set.
+    SEE:
+    docs.aws.amazon.com/redshift/latest/dg/materialized-view-create-sql-command
+
+    This works for any selectable.  Consider the trivial example of this table:
+
+    >>> import sqlalchemy as sa
+    >>> from sqlalchemy_redshift.ddl import CreateMaterializedView
+    >>> engine = sa.create_engine('redshift+psycopg2://example')
+    >>> metadata = sa.MetaData()
+    >>> user = sa.Table(
+    ...     'user',
+    ...     metadata,
+    ...     sa.Column('id', sa.Integer, primary_key=True),
+    ...     sa.Column('name', sa.String)
+    ... )
+    >>> selectable = sa.select([user.c.id, user.c.name], from_obj=user)
+    >>> view = CreateMaterializedView(
+    ...     'materialized_view_of_users',
+    ...     selectable,
+    ...     distkey='id',
+    ...     sortkey='name'
+    ... )
+    >>> print(view.compile(engine))
+    <BLANKLINE>
+    CREATE MATERIALIZED VIEW materialized_view_of_users
+    DISTKEY (id) SORTKEY (name)
+    AS SELECT "user".id, "user".name
+    FROM "user"
+    <BLANKLINE>
+    <BLANKLINE>
+
+    The materialized view can take full advantage of Redshift's distributed
+    architecture via distribution styles and sort keys.
+
+    The CreateMaterializedView is a DDLElement, so it can be executed via any
+    execute() command, be it from an Engine, Session, or Connection.
     """
-    # TODO docs above
     def __init__(self, name, selectable, backup=True, diststyle=None,
                  distkey=None, sortkey=None, interleaved_sortkey=None):
+        """
+        Parameters
+        ----------
+        name: str, required
+            the name of the materialized view to be created.
+        selectable: str, required
+            the sqlalchemy selectable to be the base query for the view.
+        diststyle: str, optional
+            The diststle to use for the table attributes.  This must be one of:
+            ("ALL", "EVEN", "KEY").  If unset, Redshift passes AUTO. If KEY is
+            used, a distkey argument must be provided.  Inversely, if
+            a diststyle other than KEY is provided, a distkey argument cannot be
+            provided.
+        distkey: str or sqlalchemy.Column, optional
+            The distribution key to use the for the table attributes.  This can
+            be provided without any distsyle specified or with KEY diststyle
+            specified.
+        sortkey: str or sqlalchemy.Column (or iterable thereof), optional
+            The (compound) sort key(s) to use for the table attributes. Mutually
+            exclusive option from interleaved_sortkey.
+        interleaved_sortkey: str or sqlalchemy.Column (or iterable), optional
+            The (interleaved) sort key(s) to use for the table attributes.
+            Mutually exclusive option from sortkey.
+        """
         self.name = name
         self.selectable = selectable
         self.backup = backup
@@ -89,11 +178,11 @@ def compile_create_materialized_view(element, compiler, **kw):
     Returns the sql query that creates the materialized view
     """
 
-    text = """
+    text = """\
         CREATE MATERIALIZED VIEW {name}
         {backup}
         {table_attributes}
-        AS {selectable}
+        AS {selectable}\
     """
     table_attributes = get_table_attributes(
         compiler.preparer,
@@ -103,24 +192,55 @@ def compile_create_materialized_view(element, compiler, **kw):
         interleaved_sortkey=element.interleaved_sortkey
     )
     # Defaults to yes, so omit default cas3
-    backup = " " if element.backup else "BACKUP NO "
+    backup = "" if element.backup else "BACKUP NO "
     selectable = compiler.sql_compiler.process(element.selectable,
                                                literal_binds=True)
-
     text = text.format(
         name=element.name,
         backup=backup,
         table_attributes=table_attributes,
         selectable=selectable
     )
+    # Clean it up to have no leading spaces
+    text = "\n".join([line.strip() for line in text.split("\n") if line.strip()])
     return text
-
 
 class DropMaterializedView(DDLElement):
     """
+    Drop the materialized view from the database.
+    SEE:
+    docs.aws.amazon.com/redshift/latest/dg/materialized-view-drop-sql-command
+
+    This undoes the create command, as expected:
+
+    >>> import sqlalchemy as sa
+    >>> from sqlalchemy_redshift.ddl import DropMaterializedView
+    >>> engine = sa.create_engine('redshift+psycopg2://example')
+    >>> drop = DropMaterializedView(
+    ...     'materialized_view_of_users',
+    ...     if_exists=True
+    ... )
+    >>> print(drop.compile(engine))
+    <BLANKLINE>
+    DROP MATERIALIZED VIEW IF EXISTS materialized_view_of_users
+    <BLANKLINE>
+    <BLANKLINE>
+
+    This can be included in any execute() statement.
     """
-    #TODO document above
     def __init__(self, name, if_exists=False):
+        """
+        Build the DropMaterializedView DDLElement.
+
+        Parameters
+        ----------
+        name: str
+            name of the materialized view to drop
+        if_exists: bool, optional
+            if True, the IF EXISTS clause is added. This will make the query
+            successful even if the view does not exist, i.e. it lets you drop
+            a non-existant view. Defaults to False.
+        """
         self.name = name
         self.if_exists = if_exists
 

--- a/sqlalchemy_redshift/ddl.py
+++ b/sqlalchemy_redshift/ddl.py
@@ -4,8 +4,10 @@ from sqlalchemy.schema import DDLElement
 
 from .compat import string_types
 
+
 def _check_if_key_exists(key):
     return isinstance(key, sa.Column) or key
+
 
 def get_table_attributes(preparer,
                          diststyle=None,
@@ -20,20 +22,21 @@ def get_table_attributes(preparer,
     ----------
     preparer: RedshiftIdentifierPreparer, required
         The preparer associated with the compiler, usually accessed through
-        compiler.preparer.  You can use a RedshiftDDLCompiler instance to access
-        it.
+        compiler.preparer.  You can use a RedshiftDDLCompiler instance to
+        access it.
     diststyle: str, optional
         The diststle to use for the table attributes.  This must be one of:
-        ("ALL", "EVEN", "KEY").  If unset, Redshift passes AUTO. If KEY is used,
+        ("ALL", "EVEN", "KEY").  If unset, Redshift passes AUTO. If KEY is used
         a distkey argument must be provided.  Inversely, if a diststyle other
         than KEY is provided, a distkey argument cannot be provided.
     distkey: str or sqlalchemy.Column, optional
         The distribution key to use the for the table attributes.  This can be
-        provided without any distsyle specified or with KEY diststyle specified.
+        provided without any distsyle specified or with KEY diststyle
+        specified.
     sortkey: str or sqlalchemy.Column (or iterable thereof), optional
         The (compound) sort key(s) to use for the table attributes. Mutually
         exclusive option from interleaved_sortkey.
-    interleaved_sortkey: str or sqlalchemy.Column (or iterable thereof), optional
+    interleaved_sortkey: str or sqlalchemy.Column (or iterable), optional
         The (interleaved) sort key(s) to use for the table attributes. Mutually
         exclusive option from sortkey.
 
@@ -150,15 +153,15 @@ class CreateMaterializedView(DDLElement):
             The diststle to use for the table attributes.  This must be one of:
             ("ALL", "EVEN", "KEY").  If unset, Redshift passes AUTO. If KEY is
             used, a distkey argument must be provided.  Inversely, if
-            a diststyle other than KEY is provided, a distkey argument cannot be
-            provided.
+            a diststyle other than KEY is provided, a distkey argument cannot
+            be provided.
         distkey: str or sqlalchemy.Column, optional
             The distribution key to use the for the table attributes.  This can
             be provided without any distsyle specified or with KEY diststyle
             specified.
         sortkey: str or sqlalchemy.Column (or iterable thereof), optional
-            The (compound) sort key(s) to use for the table attributes. Mutually
-            exclusive option from interleaved_sortkey.
+            The (compound) sort key(s) to use for the table attributes.
+            Mutually exclusive option from interleaved_sortkey.
         interleaved_sortkey: str or sqlalchemy.Column (or iterable), optional
             The (interleaved) sort key(s) to use for the table attributes.
             Mutually exclusive option from sortkey.
@@ -202,8 +205,10 @@ def compile_create_materialized_view(element, compiler, **kw):
         selectable=selectable
     )
     # Clean it up to have no leading spaces
-    text = "\n".join([line.strip() for line in text.split("\n") if line.strip()])
+    text = "\n".join([line.strip() for line in text.split("\n")
+                      if line.strip()])
     return text
+
 
 class DropMaterializedView(DDLElement):
     """

--- a/sqlalchemy_redshift/ddl.py
+++ b/sqlalchemy_redshift/ddl.py
@@ -1,16 +1,73 @@
 import sqlalchemy as sa
-from sqlalchemy import exc as sa_exc
+from sqlalchemy import exc as sa_exc, Column
 from sqlalchemy.ext import compiler as sa_compiler
-from sqlalchemy.sql import expression as sa_expression
 from sqlalchemy.schema import DDLElement
 
-from .dialect import RedshiftDDLCompiler
+from .compat import string_types
+
+def _check_if_key_exists(key):
+    return isinstance(key, Column) or key
+
+def get_table_attributes(preparer,
+                         diststyle=None,
+                         distkey=None,
+                         sortkey=None,
+                         interleaved_sortkey=None):
+    """
+    Parse the table attributes into an acceptable string for Redshift,
+    checking for valid combinations of distribution options.
+
+    Parameters
+    ----------
+    preparer: RedshiftIdentifierPreparer
+        TODO
+    """
+    # TODO fill out above
+    text = ""
+    has_distkey = _check_if_key_exists(distkey)
+    if diststyle:
+        diststyle = diststyle.upper()
+        if diststyle not in ('EVEN', 'KEY', 'ALL'):
+            raise sa_exc.ArgumentError(
+                u"diststyle {0} is invalid".format(diststyle)
+            )
+        if diststyle != 'KEY' and has_distkey:
+            raise sa_exc.ArgumentError(
+                u"DISTSTYLE EVEN/ALL is not compatible with a DISTKEY."
+            )
+        text += " DISTSTYLE " + diststyle
+
+    if has_distkey:
+        if isinstance(distkey, Column):
+            distkey = distkey.name
+        text += " DISTKEY ({0})".format(preparer.quote(distkey))
+
+    has_sortkey = _check_if_key_exists(sortkey)
+    has_interleaved = _check_if_key_exists(interleaved_sortkey)
+    if has_sortkey and has_interleaved:
+        raise sa_exc.ArgumentError(
+            "Parameters sortkey and interleaved_sortkey are "
+            "mutually exclusive; you may not specify both."
+        )
+    if has_sortkey or has_interleaved:
+        keys = sortkey if has_sortkey else interleaved_sortkey
+        if isinstance(keys, (string_types, Column)):
+            keys = [keys]
+        keys = [key.name if isinstance(key, Column) else key
+                for key in keys]
+        if interleaved_sortkey:
+            text += " INTERLEAVED"
+        sortkey_string = ", ".join(preparer.quote(key)
+                                   for key in keys)
+        text += " SORTKEY ({0})".format(sortkey_string)
+    return text
+
 
 class CreateMaterializedView(DDLElement):
     """
     """
     # TODO docs above
-    def __init__(self, name, selectable, backup=True, diststyle=None, 
+    def __init__(self, name, selectable, backup=True, diststyle=None,
                  distkey=None, sortkey=None, interleaved_sortkey=None):
         self.name = name
         self.selectable = selectable
@@ -19,6 +76,7 @@ class CreateMaterializedView(DDLElement):
         self.distkey = distkey
         self.sortkey = sortkey
         self.interleaved_sortkey = interleaved_sortkey
+
 
 @sa_compiler.compiles(CreateMaterializedView)
 def compile_create_materialized_view(element, compiler, **kw):
@@ -34,7 +92,7 @@ def compile_create_materialized_view(element, compiler, **kw):
     """
 
     # TODO check element.preparer is the right type
-    table_attributes = RedshiftDDLCompiler.get_table_attributes(
+    table_attributes = get_table_attributes(
         element.preparer,
         diststyle=element.diststyle,
         distkey=element.distkey,

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -60,8 +60,9 @@ __all__ = (
 
     'CopyCommand', 'UnloadFromSelect', 'RedshiftDialect', 'Compression',
     'Encoding', 'Format', 'CreateLibraryCommand', 'AlterTableAppendCommand',
+    'RefereshMaterializedView',
 
-    'CreateMaterializedView'
+    'CreateMaterializedView', 'DropMaterializedView'
 )
 
 

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -23,6 +23,7 @@ from .commands import (
     CreateLibraryCommand, AlterTableAppendCommand,
 )
 from .compat import string_types
+from .ddl import CreateMaterializedView
 
 try:
     import alembic
@@ -60,6 +61,8 @@ __all__ = (
 
     'CopyCommand', 'UnloadFromSelect', 'RedshiftDialect', 'Compression',
     'Encoding', 'Format', 'CreateLibraryCommand', 'AlterTableAppendCommand',
+
+    'CreateMaterializedView'
 )
 
 
@@ -341,8 +344,12 @@ class RedshiftDDLCompiler(PGDDLCompiler):
         Parse the table attributes into an acceptable string for Redshift,
         checking for valid combinations of distribution options.
 
-        :param diststyle:
+        Parameters
+        ----------
+        preparer: RedshiftIdentifierPreparer
+            TODO
         """
+        # TODO fill out above
         text = ""
         if diststyle:
             diststyle = diststyle.upper()

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -22,7 +22,9 @@ from .commands import (
     CopyCommand, UnloadFromSelect, Format, Compression, Encoding,
     CreateLibraryCommand, AlterTableAppendCommand, RefereshMaterializedView
 )
-from .ddl import CreateMaterializedView, DropMaterializedView, get_table_attributes
+from .ddl import (
+    CreateMaterializedView, DropMaterializedView, get_table_attributes
+)
 
 try:
     import alembic

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -377,7 +377,7 @@ class RedshiftDDLCompiler(PGDDLCompiler):
 
     def post_create_table(self, table):
         info = table.dialect_options['redshift']
-        return self.get_table_attributes(self, self.preparer, **info)
+        return self.get_table_attributes(self.preparer, **info)
 
 
     def get_column_specification(self, column, **kwargs):

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -20,7 +20,7 @@ from sqlalchemy.dialects.postgresql import DOUBLE_PRECISION
 
 from .commands import (
     CopyCommand, UnloadFromSelect, Format, Compression, Encoding,
-    CreateLibraryCommand, AlterTableAppendCommand, RefereshMaterializedView
+    CreateLibraryCommand, AlterTableAppendCommand, RefreshMaterializedView
 )
 from .ddl import (
     CreateMaterializedView, DropMaterializedView, get_table_attributes
@@ -62,7 +62,7 @@ __all__ = (
 
     'CopyCommand', 'UnloadFromSelect', 'RedshiftDialect', 'Compression',
     'Encoding', 'Format', 'CreateLibraryCommand', 'AlterTableAppendCommand',
-    'RefereshMaterializedView',
+    'RefreshMaterializedView',
 
     'CreateMaterializedView', 'DropMaterializedView'
 )

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -20,9 +20,9 @@ from sqlalchemy.dialects.postgresql import DOUBLE_PRECISION
 
 from .commands import (
     CopyCommand, UnloadFromSelect, Format, Compression, Encoding,
-    CreateLibraryCommand, AlterTableAppendCommand,
+    CreateLibraryCommand, AlterTableAppendCommand, RefereshMaterializedView
 )
-from .ddl import CreateMaterializedView, get_table_attributes
+from .ddl import CreateMaterializedView, DropMaterializedView, get_table_attributes
 
 try:
     import alembic

--- a/tests/test_copy_command.py
+++ b/tests/test_copy_command.py
@@ -3,7 +3,6 @@ import sqlalchemy as sa
 from sqlalchemy import exc as sa_exc
 
 from sqlalchemy_redshift import dialect
-from sqlalchemy_redshift import commands
 from rs_sqla_test_utils.utils import clean, compile_query
 
 access_key_id = 'IO1IWSZL5YRFM3BEW256'
@@ -106,8 +105,8 @@ def test_format():
 
 
 @pytest.mark.parametrize('format_type', (
-    commands.Format.orc,
-    commands.Format.parquet,
+    dialect.Format.orc,
+    dialect.Format.parquet,
 ))
 def test_format__columnar(format_type):
     expected_result = """
@@ -140,7 +139,7 @@ def test_invalid_format():
 def test_fixed_width_format_without_widths():
     copy = dialect.CopyCommand(
         tbl,
-        format=commands.Format.fixed_width,
+        format=dialect.Format.fixed_width,
         data_location='s3://bucket',
         access_key_id=access_key_id,
         secret_access_key=secret_access_key

--- a/tests/test_create_library.py
+++ b/tests/test_create_library.py
@@ -1,4 +1,4 @@
-from sqlalchemy_redshift import commands
+from sqlalchemy_redshift import dialect
 from rs_sqla_test_utils.utils import clean, compile_query
 
 # These are fake credentials for the tests.
@@ -26,7 +26,7 @@ def test_basic():
         WITH CREDENTIALS AS '{creds}'
     """.format(name=name, where=where, creds=CREDS)
 
-    cmd = commands.CreateLibraryCommand(
+    cmd = dialect.CreateLibraryCommand(
         name, where, access_key_id=ACCESS_KEY_ID,
         secret_access_key=SECRET_ACCESS_KEY)
     assert clean(expected_result) == clean(compile_query(cmd))
@@ -43,7 +43,7 @@ def test_or_replace():
         WITH CREDENTIALS AS '{creds}'
     """.format(name=name, where=where, creds=CREDS)
 
-    cmd = commands.CreateLibraryCommand(
+    cmd = dialect.CreateLibraryCommand(
         name, where, access_key_id=ACCESS_KEY_ID,
         secret_access_key=SECRET_ACCESS_KEY, replace=True)
     assert clean(expected_result) == clean(compile_query(cmd))
@@ -62,7 +62,7 @@ def test_region():
         REGION '{region}'
     """.format(name=name, where=where, creds=CREDS, region=region)
 
-    cmd = commands.CreateLibraryCommand(
+    cmd = dialect.CreateLibraryCommand(
         name, where, access_key_id=ACCESS_KEY_ID,
         secret_access_key=SECRET_ACCESS_KEY, region=region)
     assert clean(expected_result) == clean(compile_query(cmd))
@@ -81,7 +81,7 @@ def test_everything():
         REGION '{region}'
     """.format(name=name, where=where, creds=CREDS, region=region)
 
-    cmd = commands.CreateLibraryCommand(
+    cmd = dialect.CreateLibraryCommand(
         name, where, access_key_id=ACCESS_KEY_ID,
         secret_access_key=SECRET_ACCESS_KEY, replace=True, region=region)
     assert clean(expected_result) == clean(compile_query(cmd))

--- a/tests/test_ddl_compiler.py
+++ b/tests/test_ddl_compiler.py
@@ -2,7 +2,7 @@ import difflib
 
 import pytest
 from sqlalchemy import Table, Column, Integer, String, MetaData
-from sqlalchemy.exc import CompileError
+from sqlalchemy.exc import ArgumentError
 from sqlalchemy.schema import CreateTable
 
 from sqlalchemy_redshift.dialect import RedshiftDDLCompiler, RedshiftDialect
@@ -90,7 +90,7 @@ class TestDDLCompiler(object):
 
         create_table = CreateTable(table)
 
-        with pytest.raises(CompileError):
+        with pytest.raises(ArgumentError):
             compiler.process(create_table)
 
     def test_create_table_with_distkey(self, compiler):

--- a/tests/test_get_table_attributes.py
+++ b/tests/test_get_table_attributes.py
@@ -1,5 +1,5 @@
 import pytest
-from sqlalchemy import exc as sa_exc, Integer
+from sqlalchemy import exc as sa_exc, Integer, Column
 
 from sqlalchemy_redshift import ddl, dialect
 

--- a/tests/test_get_table_attributes.py
+++ b/tests/test_get_table_attributes.py
@@ -66,9 +66,9 @@ def test_table_attributes_two_sort_key_interleaved(preparer, sortkey):
 
 def test_table_attributes_one_sort_one_interleaved_raises(preparer):
     with pytest.raises(sa_exc.ArgumentError):
-        _ = ddl.get_table_attributes(preparer,
-                                     sortkey="b_key",
-                                     interleaved_sortkey="b_key")
+        ddl.get_table_attributes(preparer,
+                                 sortkey="b_key",
+                                 interleaved_sortkey="b_key")
 
 
 def test_dist_key_with_key_diststyle(preparer):
@@ -78,15 +78,15 @@ def test_dist_key_with_key_diststyle(preparer):
 
 def test_no_distkey_with_key_diststyle(preparer):
     with pytest.raises(sa_exc.ArgumentError):
-        _ = ddl.get_table_attributes(preparer, diststyle="KEY")
+        ddl.get_table_attributes(preparer, diststyle="KEY")
 
 
 def test_distkey_with_other_diststyles(preparer):
     for style in ("EVEN", "NONE", "ALL"):
         with pytest.raises(sa_exc.ArgumentError):
-            _ = ddl.get_table_attributes(preparer,
-                                         diststyle=style,
-                                         distkey="a_key")
+            ddl.get_table_attributes(preparer,
+                                     diststyle=style,
+                                     distkey="a_key")
 
 
 def test_all_diststyle(preparer):
@@ -101,4 +101,4 @@ def test_even_diststyle(preparer):
 
 def test_bad_diststyle(preparer):
     with pytest.raises(sa_exc.ArgumentError):
-        _ = ddl.get_table_attributes(preparer, diststyle="BAD_SHOULD_FAIL")
+        ddl.get_table_attributes(preparer, diststyle="BAD_SHOULD_FAIL")

--- a/tests/test_get_table_attributes.py
+++ b/tests/test_get_table_attributes.py
@@ -1,0 +1,87 @@
+import pytest
+import sqlalchemy as sa
+from sqlalchemy import exc as sa_exc, Integer
+from sqlalchemy import Table, Column, Integer, String, MetaData
+
+from sqlalchemy_redshift import ddl, dialect
+from sqlalchemy_redshift import commands
+from rs_sqla_test_utils.utils import clean, compile_query
+
+@pytest.fixture
+def preparer():
+    compiler = dialect.RedshiftDDLCompiler(dialect.RedshiftDialect(), None)
+    return compiler.preparer
+
+def test_table_attributes_empty(preparer):
+    # Test the null case
+    text = ddl.get_table_attributes(preparer)
+    expected = ""
+    assert expected == text
+
+@pytest.mark.parametrize('distkey', (
+    "a_key",
+    Column("a_key", Integer)))
+def test_table_attributes_dist_key(preparer, distkey):
+    text = ddl.get_table_attributes(preparer, distkey=distkey)
+    assert text == " DISTKEY (a_key)"
+
+@pytest.mark.parametrize('sortkey', (
+    "b_key",
+    ["b_key"],
+    Column("b_key", Integer)))
+def test_table_attributes_dist_key_one_sort_key(preparer, sortkey):
+    text = ddl.get_table_attributes(preparer, distkey="a_key", sortkey=sortkey)
+    assert text == " DISTKEY (a_key) SORTKEY (b_key)"
+
+@pytest.mark.parametrize('sortkey', ("b_key", ["b_key"]))
+def test_table_attributes__one_sort_key(preparer, sortkey):
+    text = ddl.get_table_attributes(preparer, sortkey=sortkey)
+    assert text == " SORTKEY (b_key)"
+
+@pytest.mark.parametrize('sortkey', (("b_key", "c_key"), ["b_key", "c_key"]))
+def test_table_attributes_two_sort_key(preparer, sortkey):
+    text = ddl.get_table_attributes(preparer, sortkey=sortkey)
+    assert text == " SORTKEY (b_key, c_key)"
+
+@pytest.mark.parametrize('sortkey', ("b_key", ["b_key"]))
+def test_table_attributes_one_sort_key_interleaved(preparer, sortkey):
+    # A single interleaved key doesn't make too much sense, but redshift doesn't
+    # complain, so neither should we.
+    text = ddl.get_table_attributes(preparer, interleaved_sortkey=sortkey)
+    assert text == " INTERLEAVED SORTKEY (b_key)"
+
+@pytest.mark.parametrize('sortkey', (("b_key", "c_key"), ["b_key", "c_key"]))
+def test_table_attributes_two_sort_key_interleaved(preparer, sortkey):
+    text = ddl.get_table_attributes(preparer, interleaved_sortkey=sortkey)
+    assert text == " INTERLEAVED SORTKEY (b_key, c_key)"
+
+def test_table_attributes_one_sort_one_interleaved_raises(preparer):
+    with pytest.raises(sa_exc.ArgumentError):
+        _ = ddl.get_table_attributes(preparer,
+                                     sortkey="b_key",
+                                     interleaved_sortkey="b_key")
+
+def test_dist_key_with_key_diststyle(preparer):
+    text = ddl.get_table_attributes(preparer, distkey="a_key", diststyle="KEY")
+    assert text == " DISTSTYLE KEY DISTKEY (a_key)"
+
+def test_no_distkey_with_key_diststyle(preparer):
+    with pytest.raises(sa_exc.ArgumentError):
+        _ = ddl.get_table_attributes(preparer, diststyle="KEY")
+
+def test_distkey_with_other_diststyles(preparer):
+    for style in ("EVEN", "NONE", "ALL"):
+        with pytest.raises(sa_exc.ArgumentError):
+            _ = ddl.get_table_attributes(preparer, diststyle=style, distkey="a_key")
+
+def test_all_diststyle(preparer):
+    text = ddl.get_table_attributes(preparer, diststyle="ALL")
+    assert text == " DISTSTYLE ALL"
+
+def test_even_diststyle(preparer):
+    text = ddl.get_table_attributes(preparer, diststyle="EVEN")
+    assert text == " DISTSTYLE EVEN"
+
+def test_bad_diststyle(preparer):
+    with pytest.raises(sa_exc.ArgumentError):
+        _ = ddl.get_table_attributes(preparer, diststyle="BAD_SHOULD_FAIL")

--- a/tests/test_get_table_attributes.py
+++ b/tests/test_get_table_attributes.py
@@ -84,7 +84,9 @@ def test_no_distkey_with_key_diststyle(preparer):
 def test_distkey_with_other_diststyles(preparer):
     for style in ("EVEN", "NONE", "ALL"):
         with pytest.raises(sa_exc.ArgumentError):
-            _ = ddl.get_table_attributes(preparer, diststyle=style, distkey="a_key")
+            _ = ddl.get_table_attributes(preparer,
+                                         diststyle=style,
+                                         distkey="a_key")
 
 
 def test_all_diststyle(preparer):

--- a/tests/test_get_table_attributes.py
+++ b/tests/test_get_table_attributes.py
@@ -48,8 +48,8 @@ def test_table_attributes_two_sort_key(preparer, sortkey):
 
 @pytest.mark.parametrize('sortkey', ("b_key", ["b_key"]))
 def test_table_attributes_one_sort_key_interleaved(preparer, sortkey):
-    # A single interleaved key doesn't make too much sense, but redshift doesn't
-    # complain, so neither should we.
+    # A single interleaved key doesn't make too much sense, but redshift
+    # doesn't complain, so neither should we.
     text = ddl.get_table_attributes(preparer, interleaved_sortkey=sortkey)
     assert text == " INTERLEAVED SORTKEY (b_key)"
 

--- a/tests/test_get_table_attributes.py
+++ b/tests/test_get_table_attributes.py
@@ -7,10 +7,12 @@ from sqlalchemy_redshift import ddl, dialect
 from sqlalchemy_redshift import commands
 from rs_sqla_test_utils.utils import clean, compile_query
 
+
 @pytest.fixture
 def preparer():
     compiler = dialect.RedshiftDDLCompiler(dialect.RedshiftDialect(), None)
     return compiler.preparer
+
 
 def test_table_attributes_empty(preparer):
     # Test the null case
@@ -18,12 +20,14 @@ def test_table_attributes_empty(preparer):
     expected = ""
     assert expected == text
 
+
 @pytest.mark.parametrize('distkey', (
     "a_key",
     Column("a_key", Integer)))
 def test_table_attributes_dist_key(preparer, distkey):
     text = ddl.get_table_attributes(preparer, distkey=distkey)
     assert text == " DISTKEY (a_key)"
+
 
 @pytest.mark.parametrize('sortkey', (
     "b_key",
@@ -33,15 +37,18 @@ def test_table_attributes_dist_key_one_sort_key(preparer, sortkey):
     text = ddl.get_table_attributes(preparer, distkey="a_key", sortkey=sortkey)
     assert text == " DISTKEY (a_key) SORTKEY (b_key)"
 
+
 @pytest.mark.parametrize('sortkey', ("b_key", ["b_key"]))
 def test_table_attributes__one_sort_key(preparer, sortkey):
     text = ddl.get_table_attributes(preparer, sortkey=sortkey)
     assert text == " SORTKEY (b_key)"
 
+
 @pytest.mark.parametrize('sortkey', (("b_key", "c_key"), ["b_key", "c_key"]))
 def test_table_attributes_two_sort_key(preparer, sortkey):
     text = ddl.get_table_attributes(preparer, sortkey=sortkey)
     assert text == " SORTKEY (b_key, c_key)"
+
 
 @pytest.mark.parametrize('sortkey', ("b_key", ["b_key"]))
 def test_table_attributes_one_sort_key_interleaved(preparer, sortkey):
@@ -50,10 +57,12 @@ def test_table_attributes_one_sort_key_interleaved(preparer, sortkey):
     text = ddl.get_table_attributes(preparer, interleaved_sortkey=sortkey)
     assert text == " INTERLEAVED SORTKEY (b_key)"
 
+
 @pytest.mark.parametrize('sortkey', (("b_key", "c_key"), ["b_key", "c_key"]))
 def test_table_attributes_two_sort_key_interleaved(preparer, sortkey):
     text = ddl.get_table_attributes(preparer, interleaved_sortkey=sortkey)
     assert text == " INTERLEAVED SORTKEY (b_key, c_key)"
+
 
 def test_table_attributes_one_sort_one_interleaved_raises(preparer):
     with pytest.raises(sa_exc.ArgumentError):
@@ -61,26 +70,32 @@ def test_table_attributes_one_sort_one_interleaved_raises(preparer):
                                      sortkey="b_key",
                                      interleaved_sortkey="b_key")
 
+
 def test_dist_key_with_key_diststyle(preparer):
     text = ddl.get_table_attributes(preparer, distkey="a_key", diststyle="KEY")
     assert text == " DISTSTYLE KEY DISTKEY (a_key)"
 
+
 def test_no_distkey_with_key_diststyle(preparer):
     with pytest.raises(sa_exc.ArgumentError):
         _ = ddl.get_table_attributes(preparer, diststyle="KEY")
+
 
 def test_distkey_with_other_diststyles(preparer):
     for style in ("EVEN", "NONE", "ALL"):
         with pytest.raises(sa_exc.ArgumentError):
             _ = ddl.get_table_attributes(preparer, diststyle=style, distkey="a_key")
 
+
 def test_all_diststyle(preparer):
     text = ddl.get_table_attributes(preparer, diststyle="ALL")
     assert text == " DISTSTYLE ALL"
 
+
 def test_even_diststyle(preparer):
     text = ddl.get_table_attributes(preparer, diststyle="EVEN")
     assert text == " DISTSTYLE EVEN"
+
 
 def test_bad_diststyle(preparer):
     with pytest.raises(sa_exc.ArgumentError):

--- a/tests/test_get_table_attributes.py
+++ b/tests/test_get_table_attributes.py
@@ -1,11 +1,7 @@
 import pytest
-import sqlalchemy as sa
 from sqlalchemy import exc as sa_exc, Integer
-from sqlalchemy import Table, Column, Integer, String, MetaData
 
 from sqlalchemy_redshift import ddl, dialect
-from sqlalchemy_redshift import commands
-from rs_sqla_test_utils.utils import clean, compile_query
 
 
 @pytest.fixture

--- a/tests/test_materialized_views.py
+++ b/tests/test_materialized_views.py
@@ -1,0 +1,38 @@
+import pytest
+
+from sqlalchemy import Table, Integer, String, MetaData, Column, select
+from sqlalchemy_redshift import ddl
+from rs_sqla_test_utils.utils import clean, compile_query
+
+@pytest.fixture
+def selectable():
+    table = Table('t1',
+                  MetaData(),
+                  Column('id', Integer, primary_key=True),
+                  Column('name', String))
+    return select([table.c.id, table.c.name], from_obj=table)
+
+
+def test_basic_mv_case(selectable):
+    expected_result = """
+    CREATE MATERIALIZED VIEW test_view
+    AS SELECT t1.id, t1.name FROM t1
+    """
+    copy = ddl.CreateMaterializedView(
+        "test_view",
+        selectable
+    )
+    assert clean(expected_result) == clean(compile_query(copy))
+
+def test_no_backup_mv_case(selectable):
+    expected_result = """
+    CREATE MATERIALIZED VIEW test_view
+    BACKUP NO
+    AS SELECT t1.id, t1.name FROM t1
+    """
+    copy = ddl.CreateMaterializedView(
+        "test_view",
+        selectable,
+        backup=False
+    )
+    assert clean(expected_result) == clean(compile_query(copy))

--- a/tests/test_materialized_views.py
+++ b/tests/test_materialized_views.py
@@ -96,3 +96,15 @@ def test_interleaved_sortkey_materialized_view(selectable):
             interleaved_sortkey=key
         )
         assert clean(expected_result) == clean(compile_query(view))
+
+
+def test_drop_materialized_view():
+    expected_result = "DROP MATERIALIZED VIEW test_view"
+    view = ddl.DropMaterializedView("test_view")
+    assert clean(expected_result) == clean(compile_query(view))
+
+
+def test_drop_materialized_view_if_exists():
+    expected_result = "DROP MATERIALIZED VIEW IF EXISTS test_view"
+    view = ddl.DropMaterializedView("test_view", if_exists=True)
+    assert clean(expected_result) == clean(compile_query(view))

--- a/tests/test_materialized_views.py
+++ b/tests/test_materialized_views.py
@@ -113,5 +113,5 @@ def test_drop_materialized_view_if_exists():
 
 def test_refresh_materialized_view():
     expected_result = "REFRESH MATERIALIZED VIEW test_view"
-    view = commands.RefereshMaterializedView("test_view")
+    view = commands.RefreshMaterializedView("test_view")
     assert clean(expected_result) == clean(compile_query(view))

--- a/tests/test_materialized_views.py
+++ b/tests/test_materialized_views.py
@@ -1,7 +1,7 @@
 import pytest
 
 from sqlalchemy import Table, Integer, String, MetaData, Column, select
-from sqlalchemy_redshift import ddl
+from sqlalchemy_redshift import ddl, commands
 from rs_sqla_test_utils.utils import clean, compile_query
 
 @pytest.fixture
@@ -107,4 +107,9 @@ def test_drop_materialized_view():
 def test_drop_materialized_view_if_exists():
     expected_result = "DROP MATERIALIZED VIEW IF EXISTS test_view"
     view = ddl.DropMaterializedView("test_view", if_exists=True)
+    assert clean(expected_result) == clean(compile_query(view))
+
+def test_refresh_materialized_view():
+    expected_result = "REFRESH MATERIALIZED VIEW test_view"
+    view = commands.RefereshMaterializedView("test_view")
     assert clean(expected_result) == clean(compile_query(view))

--- a/tests/test_materialized_views.py
+++ b/tests/test_materialized_views.py
@@ -4,6 +4,7 @@ from sqlalchemy import Table, Integer, String, MetaData, Column, select
 from sqlalchemy_redshift import ddl, commands
 from rs_sqla_test_utils.utils import clean, compile_query
 
+
 @pytest.fixture
 def selectable():
     table = Table('t1',
@@ -108,6 +109,7 @@ def test_drop_materialized_view_if_exists():
     expected_result = "DROP MATERIALIZED VIEW IF EXISTS test_view"
     view = ddl.DropMaterializedView("test_view", if_exists=True)
     assert clean(expected_result) == clean(compile_query(view))
+
 
 def test_refresh_materialized_view():
     expected_result = "REFRESH MATERIALIZED VIEW test_view"

--- a/tests/test_materialized_views.py
+++ b/tests/test_materialized_views.py
@@ -13,26 +13,86 @@ def selectable():
     return select([table.c.id, table.c.name], from_obj=table)
 
 
-def test_basic_mv_case(selectable):
+def test_basic_materialized_view(selectable):
     expected_result = """
     CREATE MATERIALIZED VIEW test_view
     AS SELECT t1.id, t1.name FROM t1
     """
-    copy = ddl.CreateMaterializedView(
+    view = ddl.CreateMaterializedView(
         "test_view",
         selectable
     )
-    assert clean(expected_result) == clean(compile_query(copy))
+    assert clean(expected_result) == clean(compile_query(view))
 
-def test_no_backup_mv_case(selectable):
+
+def test_no_backup_materialized_view(selectable):
     expected_result = """
     CREATE MATERIALIZED VIEW test_view
     BACKUP NO
     AS SELECT t1.id, t1.name FROM t1
     """
-    copy = ddl.CreateMaterializedView(
+    view = ddl.CreateMaterializedView(
         "test_view",
         selectable,
         backup=False
     )
-    assert clean(expected_result) == clean(compile_query(copy))
+    assert clean(expected_result) == clean(compile_query(view))
+
+
+def test_diststyle_materialized_view(selectable):
+    expected_result = """
+    CREATE MATERIALIZED VIEW test_view
+    DISTSTYLE ALL
+    AS SELECT t1.id, t1.name FROM t1
+    """
+    view = ddl.CreateMaterializedView(
+        "test_view",
+        selectable,
+        diststyle='ALL'
+    )
+    assert clean(expected_result) == clean(compile_query(view))
+
+
+def test_distkey_materialized_view(selectable):
+    expected_result = """
+    CREATE MATERIALIZED VIEW test_view
+    DISTKEY (id)
+    AS SELECT t1.id, t1.name FROM t1
+    """
+    for key in ("id", selectable.c.id):
+        view = ddl.CreateMaterializedView(
+            "test_view",
+            selectable,
+            distkey=key
+        )
+        assert clean(expected_result) == clean(compile_query(view))
+
+
+def test_sortkey_materialized_view(selectable):
+    expected_result = """
+    CREATE MATERIALIZED VIEW test_view
+    SORTKEY (id)
+    AS SELECT t1.id, t1.name FROM t1
+    """
+    for key in ("id", selectable.c.id):
+        view = ddl.CreateMaterializedView(
+            "test_view",
+            selectable,
+            sortkey=key
+        )
+        assert clean(expected_result) == clean(compile_query(view))
+
+
+def test_interleaved_sortkey_materialized_view(selectable):
+    expected_result = """
+    CREATE MATERIALIZED VIEW test_view
+    INTERLEAVED SORTKEY (id)
+    AS SELECT t1.id, t1.name FROM t1
+    """
+    for key in ("id", selectable.c.id):
+        view = ddl.CreateMaterializedView(
+            "test_view",
+            selectable,
+            interleaved_sortkey=key
+        )
+        assert clean(expected_result) == clean(compile_query(view))

--- a/tests/test_materialized_views.py
+++ b/tests/test_materialized_views.py
@@ -1,7 +1,7 @@
 import pytest
 
 from sqlalchemy import Table, Integer, String, MetaData, Column, select
-from sqlalchemy_redshift import ddl, commands
+from sqlalchemy_redshift import dialect
 from rs_sqla_test_utils.utils import clean, compile_query
 
 
@@ -19,7 +19,7 @@ def test_basic_materialized_view(selectable):
     CREATE MATERIALIZED VIEW test_view
     AS SELECT t1.id, t1.name FROM t1
     """
-    view = ddl.CreateMaterializedView(
+    view = dialect.CreateMaterializedView(
         "test_view",
         selectable
     )
@@ -32,7 +32,7 @@ def test_no_backup_materialized_view(selectable):
     BACKUP NO
     AS SELECT t1.id, t1.name FROM t1
     """
-    view = ddl.CreateMaterializedView(
+    view = dialect.CreateMaterializedView(
         "test_view",
         selectable,
         backup=False
@@ -46,7 +46,7 @@ def test_diststyle_materialized_view(selectable):
     DISTSTYLE ALL
     AS SELECT t1.id, t1.name FROM t1
     """
-    view = ddl.CreateMaterializedView(
+    view = dialect.CreateMaterializedView(
         "test_view",
         selectable,
         diststyle='ALL'
@@ -61,7 +61,7 @@ def test_distkey_materialized_view(selectable):
     AS SELECT t1.id, t1.name FROM t1
     """
     for key in ("id", selectable.c.id):
-        view = ddl.CreateMaterializedView(
+        view = dialect.CreateMaterializedView(
             "test_view",
             selectable,
             distkey=key
@@ -76,7 +76,7 @@ def test_sortkey_materialized_view(selectable):
     AS SELECT t1.id, t1.name FROM t1
     """
     for key in ("id", selectable.c.id):
-        view = ddl.CreateMaterializedView(
+        view = dialect.CreateMaterializedView(
             "test_view",
             selectable,
             sortkey=key
@@ -91,7 +91,7 @@ def test_interleaved_sortkey_materialized_view(selectable):
     AS SELECT t1.id, t1.name FROM t1
     """
     for key in ("id", selectable.c.id):
-        view = ddl.CreateMaterializedView(
+        view = dialect.CreateMaterializedView(
             "test_view",
             selectable,
             interleaved_sortkey=key
@@ -101,17 +101,17 @@ def test_interleaved_sortkey_materialized_view(selectable):
 
 def test_drop_materialized_view():
     expected_result = "DROP MATERIALIZED VIEW test_view"
-    view = ddl.DropMaterializedView("test_view")
+    view = dialect.DropMaterializedView("test_view")
     assert clean(expected_result) == clean(compile_query(view))
 
 
 def test_drop_materialized_view_if_exists():
     expected_result = "DROP MATERIALIZED VIEW IF EXISTS test_view"
-    view = ddl.DropMaterializedView("test_view", if_exists=True)
+    view = dialect.DropMaterializedView("test_view", if_exists=True)
     assert clean(expected_result) == clean(compile_query(view))
 
 
 def test_refresh_materialized_view():
     expected_result = "REFRESH MATERIALIZED VIEW test_view"
-    view = commands.RefreshMaterializedView("test_view")
+    view = dialect.RefreshMaterializedView("test_view")
     assert clean(expected_result) == clean(compile_query(view))

--- a/tests/test_unload_from_select.py
+++ b/tests/test_unload_from_select.py
@@ -1,7 +1,6 @@
 import pytest
 import sqlalchemy as sa
 
-from sqlalchemy_redshift import commands
 from sqlalchemy_redshift import dialect
 
 from rs_sqla_test_utils.utils import clean, compile_query
@@ -166,7 +165,7 @@ def test_csv_format__basic():
         unload_location='s3://bucket/key',
         access_key_id=access_key_id,
         secret_access_key=secret_access_key,
-        format=commands.Format.csv
+        format=dialect.Format.csv
     )
 
     expected_result = """
@@ -193,7 +192,7 @@ def test_csv_format__bad_options_crash(delimiter, fixed_width):
         unload_location='s3://bucket/key',
         access_key_id=access_key_id,
         secret_access_key=secret_access_key,
-        format=commands.Format.csv,
+        format=dialect.Format.csv,
         delimiter=delimiter,
         fixed_width=fixed_width
     )
@@ -209,7 +208,7 @@ def test_parquet_format__basic():
         unload_location='s3://bucket/key',
         access_key_id=access_key_id,
         secret_access_key=secret_access_key,
-        format=commands.Format.parquet,
+        format=dialect.Format.parquet,
     )
 
     expected_result = """
@@ -237,7 +236,7 @@ def test_parquet_format__bad_options_crash(kwargs):
         unload_location='s3://bucket/key',
         access_key_id=access_key_id,
         secret_access_key=secret_access_key,
-        format=commands.Format.parquet,
+        format=dialect.Format.parquet,
         **kwargs
     )
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35,36,37}, lint, docs
+envlist = py{36}, lint, docs
 
 [testenv]
 passenv = PGPASSWORD

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36}, lint, docs
+envlist = py{27,34,35,36,37}, lint, docs
 
 [testenv]
 passenv = PGPASSWORD


### PR DESCRIPTION
I will be creating a DDLElement that can support Redshift's [CREATE MATERIALIZED VIEW](https://docs.aws.amazon.com/redshift/latest/dg/materialized-view-create-sql-command.html) with table attributes, noteably sortkeys and distkeys/styles.

## Todos
 - [x] Factored out and tested `table_attributes` parser
 - [x] Write the CreateMaterializedView DDLElement
 - [x] Write the DDL compiler
 - [x] Test on redshift db

## Default Todos
- [x] MIT compatible
- [x] Unit Tests
- [x] Documentation
- [x] Updated CHANGES.rst

Notes:
 * I made the `table_attributes` parser less permissive to match expected outcomes from Redshift.  I'm happy to relax this and delegate the error messages to Redshift, but it could be nice to catch them early.  Up to the maintainers.
 * It looked like the same parsing code wanted to allow `Columns` in additions to strings (and iterables thereof) to be allowed to specify keys.  I added the checked needed in if this is the case.
 * I took the liberty of making a new module `ddl`, since the `Create` and `Drop` queries are normally treated somewhat differently than `Executable` or `ClauseElement`.  This was just an observation of mind, i'm happy to move it all into `commands`.
 * Unfortunately `REFRESH MATERIALIZED VIEWS` **is** a command.  So my contribution is a little split between these two modules, perhaps awkwardly.  Happy to take advice here.
 * Finally, I made some changes to the `doc` folder to reflect the new module.  I haven't used Sphinx so much, but it all seemed pretty self explanatory.  Even so, I'm not sure how to generate the docs to check locally.  Please advise, thanks!