### PR TITLE
Add Missing `CASCADE` option to `DropMaterializedView`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,8 @@
 0.7.10 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add option to drop materialized view with CASCADE
+  (`Pull #204 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/204>`_)
 
 
 0.7.9 (2020-05-29)

--- a/sqlalchemy_redshift/ddl.py
+++ b/sqlalchemy_redshift/ddl.py
@@ -233,7 +233,7 @@ class DropMaterializedView(DDLElement):
 
     This can be included in any execute() statement.
     """
-    def __init__(self, name, if_exists=False):
+    def __init__(self, name, if_exists=False, cascade=False):
         """
         Build the DropMaterializedView DDLElement.
 
@@ -245,9 +245,14 @@ class DropMaterializedView(DDLElement):
             if True, the IF EXISTS clause is added. This will make the query
             successful even if the view does not exist, i.e. it lets you drop
             a non-existant view. Defaults to False.
+        cascade: bool, optional
+            if True, the CASCADE clause is added. This will drop all
+            views/objects in the DB that depend on this materialized view.
+            Defaults to False.
         """
         self.name = name
         self.if_exists = if_exists
+        self.cascade = cascade
 
 
 @sa_compiler.compiles(DropMaterializedView)
@@ -255,6 +260,7 @@ def compile_drop_materialized_view(element, compiler, **kw):
     """
     Formats and returns the drop statement for materialized views.
     """
-    text = "DROP MATERIALIZED VIEW {if_exists}{name}"
+    text = "DROP MATERIALIZED VIEW {if_exists}{name}{cascade}"
     if_exists = "IF EXISTS " if element.if_exists else ""
-    return text.format(if_exists=if_exists, name=element.name)
+    cascade = " CASCADE" if element.cascade else ""
+    return text.format(if_exists=if_exists, name=element.name, cascade=cascade)

--- a/tests/test_materialized_views.py
+++ b/tests/test_materialized_views.py
@@ -111,6 +111,12 @@ def test_drop_materialized_view_if_exists():
     assert clean(expected_result) == clean(compile_query(view))
 
 
+def test_drop_materialized_view_cascade():
+    expected_result = "DROP MATERIALIZED VIEW test_view CASCADE"
+    view = dialect.DropMaterializedView("test_view", cascade=True)
+    assert clean(expected_result) == clean(compile_query(view))
+
+
 def test_refresh_materialized_view():
     expected_result = "REFRESH MATERIALIZED VIEW test_view"
     view = dialect.RefreshMaterializedView("test_view")


### PR DESCRIPTION
I followed the `aws` docs to the letter in terms of options for [DROP MATERIALIZED VIEW](https://docs.aws.amazon.com/redshift/latest/dg/materialized-view-drop-sql-command.html).  Unfortunately, they omitted the common `CASCADE` argument from this documentation.

I've added a boolean flag to support this option.

## Todos
- [X] MIT compatible
- [X] Tests
- [x] Documentation
- [x] Updated CHANGES.rst
