### PR TITLE
Fix invalid SQLAlchemy version comparison

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@
 
 - Add option to drop materialized view with CASCADE
   (`Pull #204 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/204>`_)
+- Fix invalid SQLAlchemy version comparison
+  (`Pull #206 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/206>`_)
 
 
 0.7.9 (2020-05-29)

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
         # requires sqlalchemy.sql.base.DialectKWArgs.dialect_options, new in
         # version 0.9.2
         'SQLAlchemy>=0.9.2,<2.0.0',
+        'packaging',
     ],
     extras_require={
         ':python_version < "3.4"': 'enum34 >= 1.1.6, < 2.0.0'

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -1,6 +1,7 @@
 import re
 from collections import defaultdict, namedtuple
 
+from packaging.version import Version
 import pkg_resources
 import sqlalchemy as sa
 from sqlalchemy import inspect
@@ -26,6 +27,8 @@ from .ddl import (
     CreateMaterializedView, DropMaterializedView, get_table_attributes
 )
 
+sa_version = Version(sa.__version__)
+
 try:
     import alembic
 except ImportError:
@@ -36,7 +39,7 @@ else:
     from alembic.ddl.base import RenameTable
     compiles(RenameTable, 'redshift')(postgresql.visit_rename_table)
 
-    if alembic.__version__ >= '1.0.6':
+    if Version(alembic.__version__) >= Version('1.0.6'):
         from alembic.ddl.base import ColumnComment
         compiles(ColumnComment, 'redshift')(postgresql.visit_column_comment)
 
@@ -362,7 +365,7 @@ class RedshiftDDLCompiler(PGDDLCompiler):
 
     def _fetch_redshift_column_attributes(self, column):
         text = ""
-        if sa.__version__ >= '1.3.0':
+        if sa_version >= Version('1.3.0'):
             info = column.dialect_options['redshift']
         else:
             if not hasattr(column, 'info'):
@@ -656,10 +659,10 @@ class RedshiftDialect(PGDialect_psycopg2):
     def _get_column_info(self, *args, **kwargs):
         kw = kwargs.copy()
         encode = kw.pop('encode', None)
-        if sa.__version__ < '1.2.0':
+        if sa_version < Version('1.2.0'):
             # SQLAlchemy 1.2.0 introduced the 'comment' param
             del kw['comment']
-        if sa.__version__ >= '1.3.16':
+        if sa_version >= Version('1.3.16'):
             # SQLAlchemy 1.3.16 introduced generated columns,
             # not supported in redshift
             kw['generated'] = ''

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ deps =
     sqlalchemy==1.3.0
     pytest==3.10.1
     alembic==1.4.2
+    packaging==20.4
 
 [testenv:lint]
 deps =


### PR DESCRIPTION
This fix resolves a bug with invalid SQLAlchemy version comparison in the `_get_column_info` method (see discussion in the [Issue 195](https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/issues/195#issuecomment-650114126)). It includes [packaging](https://github.com/pypa/packaging) library as a dependency.

One question bothers me: `packaging` is released under the BSD-2 license, so I should mention it in this repository somehow. Should I add its licence to the `LICENSE` file?

## Todos
- [x] MIT compatible
- [x] Tests
- [x] Documentation
- [x] Updated CHANGES.rst
