### PR TITLE
Support AWS partitions with role-based credentials

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,8 @@
 0.8.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Support AWS partitions for role-based access control in COPY and UNLOAD
+  commands. This allows these commands to be used, e.g. in GovCloud.
 
 
 0.8.0 (2020-06-30)

--- a/tests/test_copy_command.py
+++ b/tests/test_copy_command.py
@@ -78,6 +78,49 @@ def test_iam_role():
     assert clean(expected_result) == clean(compile_query(copy))
 
 
+def test_iam_role_partition():
+    """Tests the use of iam role with a custom partition"""
+
+    aws_partition = 'aws-us-gov'
+    aws_account_id = '000123456789'
+    iam_role_name = 'redshiftrole'
+    creds = 'aws_iam_role=arn:{0}:iam::{1}:role/{2}'.format(
+        aws_partition,
+        aws_account_id,
+        iam_role_name,
+    )
+
+    expected_result = """
+    COPY schema1.t1 FROM 's3://mybucket/data/listing/'
+    WITH CREDENTIALS AS '{creds}'
+    """.format(creds=creds)
+
+    copy = dialect.CopyCommand(
+        tbl,
+        data_location='s3://mybucket/data/listing/',
+        aws_partition=aws_partition,
+        aws_account_id=aws_account_id,
+        iam_role_name=iam_role_name,
+    )
+    assert clean(expected_result) == clean(compile_query(copy))
+
+
+def test_iam_role_partition_validation():
+    """Tests the use of iam role with an invalid partition"""
+
+    aws_partition = 'aws-invalid'
+    aws_account_id = '000123456789'
+    iam_role_name = 'redshiftrole'
+    with pytest.raises(ValueError):
+        dialect.CopyCommand(
+            tbl,
+            data_location='s3://mybucket/data/listing/',
+            aws_partition=aws_partition,
+            aws_account_id=aws_account_id,
+            iam_role_name=iam_role_name,
+        )
+
+
 def test_format():
     expected_result = """
     COPY t1 FROM 's3://mybucket/data/listing/'


### PR DESCRIPTION
https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/88 added support for IAM Role-based authentication. This allows the user to supply an `aws_account_id` and `iam_role_name` to use with the `COPY` and `UNLOAD` commands.

The existing code [constructs](https://github.com/mtrbean/sqlalchemy-redshift/blob/61598c5e7d4acab9eee0ce0c8992a6857aca89fe/sqlalchemy_redshift/commands.py#L54-L57) an ARN for the IAM role from these parameters. However, it assumes that the account exists in the `aws` partition.

This assumption is right for most AWS regions - e.g. `us-east-1`, `eu-central-1`. But it's not right for the AWS GovCloud (US) regions or the AWS China regions.

This PR adds an `aws_partition` parameter for both the `COPY` and `UNLOAD` commands that allows those other regions to be used. It defaults to `'aws'` such that the default behavior is unchanged.

This is a common mistake when dealing with ARNs. See [the AWS docs](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html) for information about the format, including the partition.

- [x] MIT compatible
- [x] Tests
- [x] Documentation
- [x] Updated CHANGES.rst
