### PR TITLE
Require SQLAlchemy<1.4

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,8 @@
 0.8.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Explicitly require ``SQLAlchemy<1.4.0`` as reflection code is currently incompatible
+  (`Pull #218 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/218>`_)
 
 
 0.8.2 (2021-01-08)
@@ -22,8 +23,6 @@
 0.8.0 (2020-06-30)
 ------------------
 
-- Explicitly require ``SQLAlchemy<1.4.0`` as reflection code is currently incompatible
-  (`Pull #218 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/218>`_)
 - Add option to drop materialized view with CASCADE
   (`Pull #204 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/204>`_)
 - Fix invalid SQLAlchemy version comparison

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,8 @@
 0.8.0 (2020-06-30)
 ------------------
 
+- Explicitly require ``SQLAlchemy<1.4.0`` as reflection code is currently incompatible
+  (`Pull #218 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/218>`_)
 - Add option to drop materialized view with CASCADE
   (`Pull #204 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/204>`_)
 - Fix invalid SQLAlchemy version comparison

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,11 @@ setup(
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     install_requires=[
         # requires sqlalchemy.sql.base.DialectKWArgs.dialect_options, new in
-        # version 0.9.2
-        'SQLAlchemy>=0.9.2,<2.0.0',
+        # version 0.9.2;
+        # this library is currently incompatible with SQAlchemy 1.4 due to
+        # breaking API changes;
+        # see https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/issues/214
+        'SQLAlchemy>=0.9.2,<1.4.0',
         'packaging',
     ],
     extras_require={

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ deps =
     pytest==3.10.1
     alembic==1.4.2
     packaging==20.4
+    typing==3.7.4.3
 
 [testenv:lint]
 deps =


### PR DESCRIPTION
## Todos
- [x] MIT compatible
- [x] Tests
- [x] Documentation
- [x] Updated CHANGES.rst

This is a hopefully temporary mitigation to make it less likely for folks to encounter https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/issues/214 until this library is made compatible with 1.4+