### PR TITLE
SQLAlchemy v1.4.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,11 @@ sudo: false
 language: python
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
   - "3.7"
+  - "3.8"
+  - "3.9"
 
 env:
   global:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 0.8.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- SQLAlchemy 1.4.x support
 
 
 0.8.2 (2021-01-08)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ import time
 
 try:
     from urllib import parse as urlparse
-except:
+except ImportError:
     import urlparse
 
 import requests
@@ -31,6 +31,7 @@ def database_name_generator():
             count=i,
         )
 
+
 database_name = functools.partial(next, database_name_generator())
 
 
@@ -50,7 +51,10 @@ class DatabaseTool(object):
             conn.execute('CREATE DATABASE {db_name}'.format(db_name=db_name))
 
         dburl = copy.deepcopy(self.engine.url)
-        dburl.database = db_name
+        try:
+            dburl.database = db_name
+        except AttributeError:
+            dburl = dburl.set(database=db_name)
 
         try:
             yield db.EngineDefinition(

--- a/tests/rs_sqla_test_utils/models.py
+++ b/tests/rs_sqla_test_utils/models.py
@@ -1,12 +1,16 @@
 import sqlalchemy as sa
 
 from sqlalchemy import event
+from sqlalchemy import DDL
 from sqlalchemy.ext import declarative
-from sqlalchemy.schema import CreateSchema
 
 
 Base = declarative.declarative_base()
-event.listen(Base.metadata, 'before_create', CreateSchema('other_schema'))
+event.listen(
+    Base.metadata,
+    'before_create',
+    DDL('CREATE SCHEMA IF NOT EXISTS other_schema')
+)
 
 
 class Basic(Base):

--- a/tests/test_column_loading.py
+++ b/tests/test_column_loading.py
@@ -1,8 +1,12 @@
 from unittest import TestCase
 
+from packaging.version import Version
+import sqlalchemy as sa
 from sqlalchemy.types import NullType, VARCHAR
 
 from sqlalchemy_redshift.dialect import RedshiftDialect
+
+sa_version = Version(sa.__version__)
 
 
 class TestColumnReflection(TestCase):
@@ -11,14 +15,31 @@ class TestColumnReflection(TestCase):
         Varchar columns with no length should be considered NullType columns
         """
         dialect = RedshiftDialect()
-        column_info = dialect._get_column_info(
-            'Null Column',
-            'character varying', None, False, {}, {}, 'default', 'test column'
+
+        null_info = dialect._get_column_info(
+            name='Null Column',
+            format_type='character varying',
+            default=None,
+            notnull=False,
+            domains={},
+            enums=[],
+            schema='default',
+            encode='',
+            comment='test column',
+            identity=None
         )
-        assert isinstance(column_info['type'], NullType)
-        column_info_1 = dialect._get_column_info(
-            'character column',
-            'character varying(30)', None, False, {}, {}, 'default',
-            comment='test column'
+        assert isinstance(null_info['type'], NullType)
+
+        varchar_info = dialect._get_column_info(
+            name='character column',
+            format_type='character varying(30)',
+            default=None,
+            notnull=False,
+            domains={},
+            enums=[],
+            schema='default',
+            encode='',
+            comment='test column',
+            identity=None
         )
-        assert isinstance(column_info_1['type'], VARCHAR)
+        assert isinstance(varchar_info['type'], VARCHAR)

--- a/tests/test_delete_stmt.py
+++ b/tests/test_delete_stmt.py
@@ -32,8 +32,11 @@ This same query needs to be written like this in Redshift:
 """
 
 import sqlalchemy as sa
+from packaging.version import Version
 
 from rs_sqla_test_utils.utils import clean, compile_query
+
+sa_version = Version(sa.__version__)
 
 
 meta = sa.MetaData()
@@ -116,10 +119,14 @@ def test_delete_stmt_simplewhereclause2():
     del_stmt = sa.delete(customers).where(
         customers.c.email.endswith('test.com')
     )
-    expected = """
-        DELETE FROM customers
-        WHERE customers.email
-        LIKE '%%' || 'test.com'"""
+    if sa_version >= Version('1.4.0'):
+        expected = """
+            DELETE FROM customers
+            WHERE (customers.email LIKE '%%' || 'test.com')"""
+    else:
+        expected = """
+            DELETE FROM customers
+            WHERE customers.email LIKE '%%' || 'test.com'"""
     assert clean(compile_query(del_stmt)) == clean(expected)
 
 

--- a/tests/test_reflection_views.py
+++ b/tests/test_reflection_views.py
@@ -14,14 +14,18 @@ def test_view_reflection(redshift_engine):
     view_query = "SELECT my_table.col1, my_table.col2 FROM my_table"
     view_ddl = "CREATE VIEW my_view AS %s" % view_query
     conn = redshift_engine.connect()
-    conn.execute(table_ddl)
-    conn.execute(view_ddl)
-    insp = inspect(redshift_engine)
-    view_definition = insp.get_view_definition('my_view')
-    assert(clean(compile_query(view_definition)) == clean(view_query))
-    view = Table('my_view', MetaData(),
-                 autoload=True, autoload_with=redshift_engine)
-    assert(len(view.columns) == 2)
+    try:
+        conn.execute(table_ddl)
+        conn.execute(view_ddl)
+        insp = inspect(redshift_engine)
+        view_definition = insp.get_view_definition('my_view')
+        assert(clean(compile_query(view_definition)) == clean(view_query))
+        view = Table('my_view', MetaData(),
+                     autoload=True, autoload_with=redshift_engine)
+        assert(len(view.columns) == 2)
+    finally:
+        conn.execute('DROP TABLE IF EXISTS my_table CASCADE')
+        conn.execute('DROP VIEW IF EXISTS my_view CASCADE')
 
 
 def test_late_binding_view_reflection(redshift_engine):
@@ -30,13 +34,17 @@ def test_late_binding_view_reflection(redshift_engine):
     view_ddl = ("CREATE VIEW my_late_view AS "
                 "%s WITH NO SCHEMA BINDING" % view_query)
     conn = redshift_engine.connect()
-    conn.execute(table_ddl)
-    conn.execute(view_ddl)
-    insp = inspect(redshift_engine)
-    view_definition = insp.get_view_definition('my_late_view')
+    try:
+        conn.execute(table_ddl)
+        conn.execute(view_ddl)
+        insp = inspect(redshift_engine)
+        view_definition = insp.get_view_definition('my_late_view')
 
-    # For some reason, Redshift returns the entire DDL for late binding views.
-    assert(clean(compile_query(view_definition)) == clean(view_ddl))
-    view = Table('my_late_view', MetaData(),
-                 autoload=True, autoload_with=redshift_engine)
-    assert(len(view.columns) == 2)
+        # Redshift returns the entire DDL for late binding views.
+        assert(clean(compile_query(view_definition)) == clean(view_ddl))
+        view = Table('my_late_view', MetaData(),
+                     autoload=True, autoload_with=redshift_engine)
+        assert(len(view.columns) == 2)
+    finally:
+        conn.execute('DROP TABLE IF EXISTS my_table CASCADE')
+        conn.execute('DROP VIEW IF EXISTS my_late_view CASCADE')

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,21 @@
 [tox]
-envlist = py{27,34,35,36,37}, lint, docs
+envlist =
+    py35-sa13,
+    py{27,36,37,38,39}-sa{13,14},
+    lint,
+    docs
 
 [testenv]
 passenv = PGPASSWORD
-commands = py.test {posargs}
+commands = pytest {posargs}
 deps =
-    requests==2.7.0
-    psycopg2==2.7.3.2
-    sqlalchemy==1.3.0
-    pytest==3.10.1
     alembic==1.4.2
     packaging==20.4
+    psycopg2==2.8.6
+    pytest==3.10.1
+    requests==2.7.0
+    sa13: sqlalchemy==1.3.24
+    sa14: sqlalchemy==1.4.15
 
 [testenv:lint]
 deps =


### PR DESCRIPTION
Fixes #220 and adds general support for SQLAlchemy v1.4.0. In my testing v1.2.x of SQLAlchemy no longer works so I dropped support for it.

## Todos
- [x] MIT compatible
- [x] Tests
- [ ] Documentation
- [x] Updated CHANGES.rst
