### PR TITLE
Default branch refs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ sqlalchemy-redshift
 
 Amazon Redshift dialect for SQLAlchemy.
 
-.. image:: https://travis-ci.org/sqlalchemy-redshift/sqlalchemy-redshift.svg?branch=master
+.. image:: https://travis-ci.org/sqlalchemy-redshift/sqlalchemy-redshift.svg?branch=main
    :target: https://travis-ci.org/sqlalchemy-redshift/sqlalchemy-redshift
    :alt: Travis CI build status
 

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,3 +1,4 @@
 -e .
 sphinx==1.5.3
 numpydoc==0.6.0
+psycopg2-binary==2.9.1


### PR DESCRIPTION
Also adds psycopg2 dep for docs builds on readthedocs (which are currently failing).