### PR TITLE
Fix RelationKey unquoted issue. Fixes #137

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,8 @@
 0.8.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix RelationKey unquoted issue
+  (`Pull #228 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/228>`_)
 
 
 0.8.4 (2021-07-15)

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -208,6 +208,15 @@ class RelationKey(namedtuple('RelationKey', ('name', 'schema'))):
         else:
             return self.schema + "." + self.name
 
+    @classmethod
+    def _unquote(cls, part):
+        if (
+                part is not None and part.startswith('"') and
+                part.endswith('"')
+        ):
+            return part[1:-1]
+        return part
+
     def unquoted(self):
         """
         Return *key* with one level of double quotes removed.
@@ -216,14 +225,10 @@ class RelationKey(namedtuple('RelationKey', ('name', 'schema'))):
         even though the name must be quoted elsewhere.
         In particular, this happens for tables named as a keyword.
         """
-        def unquote(part):
-            if (
-                    part is not None and part.startswith('"') and
-                    part.endswith('"')
-            ):
-                return part[1:-1]
-            return part
-        return RelationKey(unquote(self.name), unquote(self.schema))
+        return RelationKey(
+            RelationKey._unquote(self.name),
+            RelationKey._unquote(self.schema)
+        )
 
 
 class RedshiftCompiler(PGCompiler):

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -217,14 +217,13 @@ class RelationKey(namedtuple('RelationKey', ('name', 'schema'))):
         In particular, this happens for tables named as a keyword.
         """
         def unquote(part):
-            if part.startswith('"') and part.endswith('"'):
+            if (
+                    part is not None and part.startswith('"') and
+                    part.endswith('"')
+            ):
                 return part[1:-1]
             return part
-
-        if self.schema is None:
-            return unquote(self.name)
-        else:
-            return unquote(self.schema) + "." + unquote(self.name)
+        return RelationKey(unquote(self.name), unquote(self.schema))
 
 
 class RedshiftCompiler(PGCompiler):

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -208,8 +208,8 @@ class RelationKey(namedtuple('RelationKey', ('name', 'schema'))):
         else:
             return self.schema + "." + self.name
 
-    @classmethod
-    def _unquote(cls, part):
+    @staticmethod
+    def _unquote(part):
         if (
                 part is not None and part.startswith('"') and
                 part.endswith('"')

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -216,10 +216,15 @@ class RelationKey(namedtuple('RelationKey', ('name', 'schema'))):
         even though the name must be quoted elsewhere.
         In particular, this happens for tables named as a keyword.
         """
-        key = str(self)
-        if key.startswith('"') and key.endswith('"'):
-            return key[1:-1]
-        return key
+        def unquote(part):
+            if part.startswith('"') and part.endswith('"'):
+                return part[1:-1]
+            return part
+
+        if self.schema is None:
+            return unquote(self.name)
+        else:
+            return unquote(self.schema) + "." + unquote(self.name)
 
 
 class RedshiftCompiler(PGCompiler):

--- a/tests/test_relationkey_unquoted.py
+++ b/tests/test_relationkey_unquoted.py
@@ -1,21 +1,27 @@
+import pytest
 from sqlalchemy_redshift.dialect import RelationKey
 
+raw_names = [
+    (
+        "table",
+        '"schema"'
+    ),
+    (
+        '"table"',
+        "schema"
+    ),
+    (
+        '"table"',
+        '"schema"'
+    ),
+    (
+        "table",
+        "schema"
+    )
+]
 
-def test_unquoted_with_quoted_schema():
-    key = RelationKey("table", '"schema"')
-    assert key.unquoted() == "schema.table"
 
-
-def test_unquoted_with_quoted_table():
-    key = RelationKey('"table"', "schema")
-    assert key.unquoted() == "schema.table"
-
-
-def test_unquoted_with_both_quoted():
-    key = RelationKey('"table"', '"schema"')
-    assert key.unquoted() == "schema.table"
-
-
-def test_unquoted_with_neither_quoted():
-    key = RelationKey("table", "schema")
-    assert key.unquoted() == "schema.table"
+@pytest.mark.parametrize("raw_table, raw_schema", raw_names)
+def test_unquoted(raw_table, raw_schema):
+    key = RelationKey(raw_table, raw_schema)
+    assert key.unquoted().__str__() == "schema.table"

--- a/tests/test_relationkey_unquoted.py
+++ b/tests/test_relationkey_unquoted.py
@@ -1,0 +1,21 @@
+from sqlalchemy_redshift.dialect import RelationKey
+
+
+def test_unquoted_with_quoted_schema():
+    key = RelationKey("table", '"schema"')
+    assert key.unquoted() == "schema.table"
+
+
+def test_unquoted_with_quoted_table():
+    key = RelationKey('"table"', "schema")
+    assert key.unquoted() == "schema.table"
+
+
+def test_unquoted_with_both_quoted():
+    key = RelationKey('"table"', '"schema"')
+    assert key.unquoted() == "schema.table"
+
+
+def test_unquoted_with_neither_quoted():
+    key = RelationKey("table", "schema")
+    assert key.unquoted() == "schema.table"


### PR DESCRIPTION
#184 reopened

- Addresses PR feedback from @novotl regarding `RelationKey.unquoted()` return type & test modifications
- Addresses PR feedback from @graingert regarding use of `pytest.mark.parameterize`.


- [X] MIT compatible
- [X] Tests
- [ ] Documentation
- [ ] Updated CHANGES.rst

`tox` has been run, no test failures seen.
