### PR TITLE
Remove support and tests for Python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ matrix:
   include:
     - python: "3.9"
       env: TOXENV=lint
+    - python: "3.9"
+      env: TOXENV=docs
 
 install: pip install tox tox-travis
 script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: xenial
 sudo: false
 language: python
 python:
-  - "3.4"
+  - "3.5"
   - "3.9"
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
 
 matrix:
   include:
-    - python: "3.6"
+    - python: "3.9"
       env: TOXENV=lint
 
 install: pip install tox tox-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,7 @@ dist: xenial
 sudo: false
 language: python
 python:
-  - "3.5"
-  - "3.6"
-  - "3.7"
-  - "3.8"
+  - "3.4"
   - "3.9"
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ dist: xenial
 sudo: false
 language: python
 python:
-  - "2.7"
   - "3.5"
   - "3.6"
   - "3.7"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,8 @@
 0.8.8 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Remove support for Python 2.7; now requires python ``>=3.4``
+  (`Pull #234 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/234>`_)
 
 
 0.8.7 (2021-10-27)

--- a/README.rst
+++ b/README.rst
@@ -16,8 +16,9 @@ The package is available on PyPI::
 
 .. warning::
 
-    This dialect requires psycopg2 library to work properly. It does not provide
-    it as required, but relies on you to select the psycopg2 distribution you need:
+    This dialect requires either ``redshift_connector`` or ``psycopg2``
+    to work properly. It does not provide
+    it as required, but relies on you to select the distribution you need:
 
     * psycopg2 - standard distribution of psycopg2, requires compilation so few system dependencies are required for it
     * psycopg2-binary - already compiled distribution (no system dependencies are required)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,7 +10,6 @@ Contents:
    ddl-compiler
    dialect
    commands
-   ddl
 
 Indices and tables
 ==================

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,8 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
     entry_points={
         'sqlalchemy.dialects': [

--- a/setup.py
+++ b/setup.py
@@ -17,16 +17,13 @@ setup(
     url='https://github.com/sqlalchemy-redshift/sqlalchemy-redshift',
     packages=['sqlalchemy_redshift', 'redshift_sqlalchemy'],
     package_data={'sqlalchemy_redshift': ['redshift-ca-bundle.crt']},
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+    python_requires='>=3.4',
     install_requires=[
         # requires sqlalchemy.sql.base.DialectKWArgs.dialect_options, new in
         # version 0.9.2
         'SQLAlchemy>=0.9.2,<2.0.0',
         'packaging',
     ],
-    extras_require={
-        ':python_version < "3.4"': 'enum34 >= 1.1.6, < 2.0.0'
-    },
     classifiers=[
         "Development Status :: 4 - Beta",
         "Environment :: Console",
@@ -34,8 +31,6 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",

--- a/sqlalchemy_redshift/compat.py
+++ b/sqlalchemy_redshift/compat.py
@@ -1,9 +1,0 @@
-import sys
-
-
-py3k = sys.version_info >= (3, 0)
-
-if py3k:
-    string_types = (str,)
-else:
-    string_types = (basestring,)  # noqa

--- a/sqlalchemy_redshift/ddl.py
+++ b/sqlalchemy_redshift/ddl.py
@@ -2,8 +2,6 @@ import sqlalchemy as sa
 from sqlalchemy.ext import compiler as sa_compiler
 from sqlalchemy.schema import DDLElement
 
-from .compat import string_types
-
 
 def _check_if_key_exists(key):
     return isinstance(key, sa.Column) or key
@@ -87,7 +85,7 @@ def get_table_attributes(preparer,
 
     if has_sortkey or has_interleaved:
         keys = sortkey if has_sortkey else interleaved_sortkey
-        if isinstance(keys, (string_types, sa.Column)):
+        if isinstance(keys, (str, sa.Column)):
             keys = [keys]
         keys = [key.name if isinstance(key, sa.Column) else key
                 for key in keys]

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps =
     sa13: sqlalchemy==1.3.24
     sa14: sqlalchemy==1.4.15
 
-[testenv:py{27,35}-sa{13,14}]
+[testenv:py{34}-sa{13,14}]
 commands = pytest -s {posargs} --dbdriver psycopg2 --dbdriver psycopg2cffi
 deps =
     alembic==1.4.2
@@ -21,7 +21,7 @@ deps =
     pytest==3.10.1
     requests==2.7.0
 
-[testenv:py{36,37,38,39}-sa{13,14}]
+[testenv:py{39}-sa{13,14}]
 commands = pytest {posargs} --dbdriver psycopg2 --dbdriver psycopg2cffi --dbdriver redshift_connector
 deps =
     alembic==1.4.2

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py35-sa13,
-    py{27,36,37,38,39}-sa{13,14},
+    py34-sa13,
+    py{39}-sa{13,14},
     lint,
     docs
 

--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,7 @@ changedir=docs
 deps=
     -rrequirements-docs.txt
 commands=
-    sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
+    sphinx-build -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
 
 [pytest]
 addopts = --doctest-modules --doctest-glob='*.rst' --ignore=setup.py --ignore=docs/conf.py

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py34-sa13,
+    py35-sa13,
     py{39}-sa{13,14},
     lint,
     docs
@@ -11,7 +11,7 @@ deps =
     sa13: sqlalchemy==1.3.24
     sa14: sqlalchemy==1.4.15
 
-[testenv:py{34}-sa{13,14}]
+[testenv:py35-sa13]
 commands = pytest -s {posargs} --dbdriver psycopg2 --dbdriver psycopg2cffi
 deps =
     alembic==1.4.2

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py35-sa13,
-    py{39}-sa{13,14},
+    py39-sa14,
     lint,
     docs
 
@@ -21,7 +21,7 @@ deps =
     pytest==3.10.1
     requests==2.7.0
 
-[testenv:py{39}-sa{13,14}]
+[testenv:py39-sa14]
 commands = pytest {posargs} --dbdriver psycopg2 --dbdriver psycopg2cffi --dbdriver redshift_connector
 deps =
     alembic==1.4.2


### PR DESCRIPTION
The next build will be 3.4+.

## Todos
- [ ] MIT compatible
- [ ] Tests
- [ ] Documentation
- [ ] Updated CHANGES.rst
