### PR TITLE
Adapt to Redshift new version format

### DIFF
--- a/sqlalchemy_redshift/__init__.py
+++ b/sqlalchemy_redshift/__init__.py
@@ -12,6 +12,7 @@ __version__ = get_distribution('sqlalchemy-redshift').version
 
 from sqlalchemy.dialects import registry
 from sqlalchemy.dialects.postgresql.base import PGDialect
+import re
 
 def _get_server_version_info(self, connection):
     v = connection.exec_driver_sql("select pg_catalog.version()").scalar()

--- a/sqlalchemy_redshift/__init__.py
+++ b/sqlalchemy_redshift/__init__.py
@@ -11,6 +11,25 @@ for package in ['psycopg2', 'psycopg2-binary', 'psycopg2cffi']:
 __version__ = get_distribution('sqlalchemy-redshift').version
 
 from sqlalchemy.dialects import registry
+from sqlalchemy.dialect.postgresql.base import PGDialect
+
+def _get_server_version_info(self, connection):
+    v = connection.exec_driver_sql("select pg_catalog.version()").scalar()
+    m = re.match(
+            r".*(?:PostgreSQL|EnterpriseDB) "
+            r"(\d+)\.?(\d+)?(?:\.(\d+))?(?:\.\d+)?(?:devel|beta)?",
+            v,
+    )
+    f not m:
+        if "Redshift" in v: # There is no way of extracting Postgres version from the new version format
+            return (8, 0, 2)
+        raise AssertionError(
+            "Could not determine version from string '%s'" % v
+        )
+    return tuple([int(x) for x in m.group(1, 2, 3) if x is not None])
+
+
+PGDialect._get_server_version_info = _get_server_version_info
 
 registry.register(
     "redshift", "sqlalchemy_redshift.dialect",

--- a/sqlalchemy_redshift/__init__.py
+++ b/sqlalchemy_redshift/__init__.py
@@ -11,7 +11,7 @@ for package in ['psycopg2', 'psycopg2-binary', 'psycopg2cffi']:
 __version__ = get_distribution('sqlalchemy-redshift').version
 
 from sqlalchemy.dialects import registry
-from sqlalchemy.dialect.postgresql.base import PGDialect
+from sqlalchemy.dialects.postgresql.base import PGDialect
 
 def _get_server_version_info(self, connection):
     v = connection.exec_driver_sql("select pg_catalog.version()").scalar()

--- a/sqlalchemy_redshift/__init__.py
+++ b/sqlalchemy_redshift/__init__.py
@@ -20,7 +20,7 @@ def _get_server_version_info(self, connection):
             r"(\d+)\.?(\d+)?(?:\.(\d+))?(?:\.\d+)?(?:devel|beta)?",
             v,
     )
-    f not m:
+    if not m:
         if "Redshift" in v: # There is no way of extracting Postgres version from the new version format
             return (8, 0, 2)
         raise AssertionError(


### PR DESCRIPTION
Hey! 

Redshift unilaterally changed its version format in its recent update. It has already affected some people, but when the clusters are going to be updated, it will affect more. In the new version, there is no way of telling which Postgres version to use, so I used the last available information "PostgreSQL 8.0.2" from https://docs.aws.amazon.com/redshift/latest/dg/r_VERSION.html. 