### PR TITLE
Support inspection of Redshift datatypes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,8 @@
 0.8.9 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Support inspection of Redshift datatypes
+  (`Pull #242 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/242>`_)
 
 
 0.8.8 (2021-11-03)

--- a/tests/test_dialect_types.py
+++ b/tests/test_dialect_types.py
@@ -161,3 +161,10 @@ def test_custom_types_reflection_inspection(
     actual = inspect.get_columns(table_name='t1', schema='public')
     assert len(actual) == 3
     assert isinstance(actual[2]['type'], custom_datatype)
+
+
+@pytest.mark.parametrize("custom_datatype", redshift_specific_datatypes)
+def test_custom_type_compilation(custom_datatype):
+    dt = custom_datatype()
+    compiled_dt = dt.compile()
+    assert compiled_dt == dt.__visit_name__

--- a/tests/test_dialect_types.py
+++ b/tests/test_dialect_types.py
@@ -1,6 +1,8 @@
 import pytest
 import sqlalchemy_redshift.dialect
 import sqlalchemy
+from sqlalchemy.engine import reflection
+from sqlalchemy import MetaData
 
 
 def test_defined_types():
@@ -130,3 +132,32 @@ def test_custom_types_ddl_generation(
     create_table = sqlalchemy.schema.CreateTable(table)
     actual = compiler.process(create_table)
     assert expected == actual
+
+
+redshift_specific_datatypes = [
+    sqlalchemy_redshift.dialect.GEOMETRY,
+    sqlalchemy_redshift.dialect.SUPER,
+    sqlalchemy_redshift.dialect.TIMETZ,
+    sqlalchemy_redshift.dialect.TIMESTAMPTZ
+]
+
+
+@pytest.mark.parametrize("custom_datatype", redshift_specific_datatypes)
+def test_custom_types_reflection_inspection(
+        custom_datatype, redshift_engine
+):
+    metadata = MetaData(bind=redshift_engine)
+    sqlalchemy.Table(
+        't1',
+        metadata,
+        sqlalchemy.Column('id', sqlalchemy.INTEGER, primary_key=True),
+        sqlalchemy.Column('name', sqlalchemy.String),
+        sqlalchemy.Column('test_col', custom_datatype),
+        schema='public'
+    )
+    metadata.create_all()
+    inspect = reflection.Inspector.from_engine(redshift_engine)
+
+    actual = inspect.get_columns(table_name='t1', schema='public')
+    assert len(actual) == 3
+    assert isinstance(actual[2]['type'], custom_datatype)


### PR DESCRIPTION
This PR modifies `RedshiftDialectMixin` to support database schema inspection of Amazon Redshift datatypes. It adds entries in `ischema_names` for these Redshift specific datatypes. It also makes a small change to the definition of `Timetz` and `Timestamptz` datatype definition for compatibility with SqlAlchemy insepctor.

Use case: Support for Redshift datatypes in Querybook Metastore

Issue: When `inspect.get_columns(...)` is called, `NullType()` is returned as the type for columns with type `geometry` and `super`, which causes issues in downstream tools like Querybook's metastore. 

Repro:
```python
from sqlalchemy.engine import reflection
from sqlalchemy import create_engine
engine = create_engine('redshift+redshift_connector://...')
inspect = reflection.Inspector.from_engine(engine)
x = inspect.get_columns(table_name='my_table', schema='public')
```

where `my_table` is defined as
```sql
create table public.my_table (c1 geometry, c2 super, c3 timetz, c4 timestamptz);
```



For columns with type `timetz` and `timestamptz`, `sa.dialects.postgresql.TIME` and `sa.dialects.postgresql.TIMESTAMP` are returned, which isn't ideal since we've defined `TIMETZ` and `TIMESTAMPTZ` datatypes within `sqlalchemy-redshift`.

[`sqlalchemy.engine.dialects.postgresql.base.PGDialect._get_column_info`](https://github.com/sqlalchemy/sqlalchemy/blob/bd1be0b7e0ecd76bdf6d26fd11cc42e1a473b319/lib/sqlalchemy/dialects/postgresql/base.py#L3736) uses the [`ischema_names`](https://github.com/sqlalchemy/sqlalchemy/blob/bd1be0b7e0ecd76bdf6d26fd11cc42e1a473b319/lib/sqlalchemy/dialects/postgresql/base.py#L2061) to map datatype string names to datatype classes.



screenshots below show the behavior before & after this change when the above use case is run:

note entries 11, 12, 15, 16

behavior before:

![Screen Shot 2021-11-16 at 9 50 19 AM](https://user-images.githubusercontent.com/7676438/142038774-5ba90df2-e5c5-4604-9baf-5a3eee6a1652.png)

behavior after:
![Screen Shot 2021-11-16 at 9 48 01 AM](https://user-images.githubusercontent.com/7676438/142038513-a693429d-964a-4efd-9c51-1795b58b560b.png)


## Todos
- [ x ] MIT compatible
- [ x ] Tests
- [ x ] Documentation
- [ x ] Updated CHANGES.rst
