### PR TITLE
Support HLLSKETCH Redshift datatypes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,8 @@
 -------------------
 
 - Nothing changed yet.
-
+- Support HLLSKETCH Redshift datatypes
+  (`Pull #246 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/246>`_)
 
 0.8.9 (2021-12-15)
 ------------------

--- a/tests/test_dialect_types.py
+++ b/tests/test_dialect_types.py
@@ -44,6 +44,9 @@ def test_defined_types():
     assert sqlalchemy_redshift.dialect.TIMETZ \
         is not sqlalchemy.sql.sqltypes.TIME
 
+    assert sqlalchemy_redshift.dialect.HLLSKETCH \
+        is not sqlalchemy.sql.sqltypes.HLLSKETCH
+
 custom_type_inheritance = [
     (
         sqlalchemy_redshift.dialect.GEOMETRY,
@@ -60,6 +63,10 @@ custom_type_inheritance = [
     (
         sqlalchemy_redshift.dialect.TIMETZ,
         sqlalchemy.sql.sqltypes.TIME
+    ),
+    (
+        sqlalchemy_redshift.dialect.HLLSKETCH,
+        sqlalchemy.sql.sqltypes.TEXT
     ),
 ]
 
@@ -111,6 +118,16 @@ column_and_ddl = [
             u"\n\tPRIMARY KEY (id)\n)\n\n"
         )
     ),
+    (
+        sqlalchemy_redshift.dialect.HLLSKETCH,
+        (
+            u"\nCREATE TABLE t1 ("
+            u"\n\tid INTEGER NOT NULL, "
+            u"\n\tname VARCHAR, "
+            u"\n\ttest_col HLLSKETCH, "
+            u"\n\tPRIMARY KEY (id)\n)\n\n"
+        )
+    ),
 ]
 
 
@@ -138,7 +155,8 @@ redshift_specific_datatypes = [
     sqlalchemy_redshift.dialect.GEOMETRY,
     sqlalchemy_redshift.dialect.SUPER,
     sqlalchemy_redshift.dialect.TIMETZ,
-    sqlalchemy_redshift.dialect.TIMESTAMPTZ
+    sqlalchemy_redshift.dialect.TIMESTAMPTZ,
+    sqlalchemy_redshift.dialect.HLLSKETCH
 ]
 
 

--- a/tests/test_dialect_types.py
+++ b/tests/test_dialect_types.py
@@ -45,7 +45,7 @@ def test_defined_types():
         is not sqlalchemy.sql.sqltypes.TIME
 
     assert sqlalchemy_redshift.dialect.HLLSKETCH \
-        is not sqlalchemy.sql.sqltypes.HLLSKETCH
+        is not sqlalchemy.sql.sqltypes.TEXT
 
 custom_type_inheritance = [
     (


### PR DESCRIPTION
Adds support for Redshift HLLSKETCH datatypes. Fixes #245.
## Todos
- [x] MIT compatible
- [x] Tests
- [x] Documentation
- [x] Updated CHANGES.rst
