### PR TITLE
Disable supports_statement_cache

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,9 +1,10 @@
 0.8.10 (unreleased)
 -------------------
 
-- Nothing changed yet.
 - Support HLLSKETCH Redshift datatypes
   (`Pull #246 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/246>`_)
+- Disable supports_statement_cache
+  (`Pull #249 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/249>`_)
 
 0.8.9 (2021-12-15)
 ------------------

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -555,6 +555,9 @@ class RedshiftDialectMixin(DefaultDialect):
 
     name = 'redshift'
     max_identifier_length = 127
+    # explicitly disables statement cache to disable warnings in logs
+    # ref: https://docs.sqlalchemy.org/en/14/core/connections.html#caching-for-third-party-dialects
+    supports_statement_cache = False
 
     statement_compiler = RedshiftCompiler
     ddl_compiler = RedshiftDDLCompiler


### PR DESCRIPTION
Partially addresses #244. When using sqlalchemy>=1.4, a warning is emitted to the logs saying `supports_statement_cache` has not been set for the current dialect. This warning can create a lot of noise in logs, so this PR sets `supports_statement_cache=False` for all of our dialects. 

Re: enabling `supports_statement_cache`, this would be nice to look into in the future as it would offer a performance improvement. I wrote some notes in #244 about what this would entail. 

## Todos
- [x] MIT compatible
- [x] Tests
- [x] Documentation
- [x] Updated CHANGES.rst
