### PR TITLE
Fix doc, lint CI dependency issues

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@
   (`Pull #246 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/246>`_)
 - Disable supports_statement_cache
   (`Pull #249 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/249>`_)
+- Fix doc, lint CI dependency issues
+  (`Pull #250 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/250>`_)
 
 0.8.9 (2021-12-15)
 ------------------

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -2,3 +2,4 @@
 sphinx==1.5.3
 numpydoc==0.6.0
 psycopg2-binary==2.9.1
+jinja2<3.1.0

--- a/sqlalchemy_redshift/__init__.py
+++ b/sqlalchemy_redshift/__init__.py
@@ -10,7 +10,7 @@ for package in ['psycopg2', 'psycopg2-binary', 'psycopg2cffi']:
 
 __version__ = get_distribution('sqlalchemy-redshift').version
 
-from sqlalchemy.dialects import registry
+from sqlalchemy.dialects import registry  # noqa
 
 registry.register(
     "redshift", "sqlalchemy_redshift.dialect",

--- a/sqlalchemy_redshift/commands.py
+++ b/sqlalchemy_redshift/commands.py
@@ -28,9 +28,9 @@ SECRET_ACCESS_KEY_RE = re.compile('[A-Za-z0-9/+=]{40}')
 TOKEN_RE = re.compile('[A-Za-z0-9/+=]+')
 AWS_PARTITIONS = frozenset({'aws', 'aws-cn', 'aws-us-gov'})
 AWS_ACCOUNT_ID_RE = re.compile('[0-9]{12}')
-IAM_ROLE_NAME_RE = re.compile('[A-Za-z0-9+=,.@\-_]{1,64}')
+IAM_ROLE_NAME_RE = re.compile('[A-Za-z0-9+=,.@\-_]{1,64}')  # noqa
 IAM_ROLE_ARN_RE = re.compile('arn:(aws|aws-cn|aws-us-gov):iam::'
-                             '[0-9]{12}:role/[A-Za-z0-9+=,.@\-_]{1,64}')
+                             '[0-9]{12}:role/[A-Za-z0-9+=,.@\-_]{1,64}')  # noqa
 
 
 def _process_aws_credentials(access_key_id=None, secret_access_key=None,

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -559,7 +559,7 @@ class RedshiftDialectMixin(DefaultDialect):
     name = 'redshift'
     max_identifier_length = 127
     # explicitly disables statement cache to disable warnings in logs
-    # ref: https://docs.sqlalchemy.org/en/14/core/connections.html#caching-for-third-party-dialects
+    # ref: https://docs.sqlalchemy.org/en/14/core/connections.html#caching-for-third-party-dialects  # noqa
     supports_statement_cache = False
 
     statement_compiler = RedshiftCompiler

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -186,7 +186,8 @@ class RedshiftTypeEngine(TypeEngine):
 
     def _default_dialect(self, default=None):
         """
-        Returns the default dialect used for TypeEngine compilation yielding String result.
+        Returns the default dialect used for TypeEngine compilation yielding
+        String result.
 
         :meth:`~sqlalchemy.sql.type_api.TypeEngine.compile`
         """
@@ -208,9 +209,9 @@ class TIMESTAMPTZ(RedshiftTypeEngine, sa.dialects.postgresql.TIMESTAMP):
     __visit_name__ = 'TIMESTAMPTZ'
 
     def __init__(self, timezone=True, precision=None):
-        # timezone param must be present as it's provided in base class so the object
-        # can be instantiated with kwargs
-        # see :meth:`~sqlalchemy.dialects.postgresql.base.PGDialect._get_column_info`
+        # timezone param must be present as it's provided in base class so the
+        # object can be instantiated with kwargs. see
+        # :meth:`~sqlalchemy.dialects.postgresql.base.PGDialect._get_column_info`
         super(TIMESTAMPTZ, self).__init__(timezone=True, precision=precision)
 
 
@@ -229,9 +230,9 @@ class TIMETZ(RedshiftTypeEngine, sa.dialects.postgresql.TIME):
     __visit_name__ = 'TIMETZ'
 
     def __init__(self, timezone=True, precision=None):
-        # timezone param must be present as it's provided in base class so the object
-        # can be instantiated with kwargs
-        # see :meth:`~sqlalchemy.dialects.postgresql.base.PGDialect._get_column_info`
+        # timezone param must be present as it's provided in base class so the
+        # object can be instantiated with kwargs. see
+        # :meth:`~sqlalchemy.dialects.postgresql.base.PGDialect._get_column_info`
         super(TIMETZ, self).__init__(timezone=True, precision=precision)
 
 
@@ -281,6 +282,7 @@ class SUPER(RedshiftTypeEngine, sa.dialects.postgresql.TEXT):
             return json.dumps(value)
         return value
 
+
 class HLLSKETCH(RedshiftTypeEngine, sa.dialects.postgresql.TEXT):
     """
     Redshift defines a HLLSKETCH column type
@@ -298,6 +300,7 @@ class HLLSKETCH(RedshiftTypeEngine, sa.dialects.postgresql.TEXT):
 
     def get_dbapi_type(self, dbapi):
         return dbapi.HLLSKETCH
+
 
 # Mapping for database schema inspection of Amazon Redshift datatypes
 REDSHIFT_ISCHEMA_NAMES = {
@@ -598,7 +601,10 @@ class RedshiftDialectMixin(DefaultDialect):
         Used in
         :meth:`~sqlalchemy.engine.dialects.postgresql.base.PGDialect._get_column_info`.
         """
-        return {**super(RedshiftDialectMixin, self).ischema_names, **REDSHIFT_ISCHEMA_NAMES}
+        return {
+            **super(RedshiftDialectMixin, self).ischema_names,
+            **REDSHIFT_ISCHEMA_NAMES
+        }
 
     @reflection.cache
     def get_columns(self, connection, table_name, schema=None, **kw):

--- a/tests/test_dialect_types.py
+++ b/tests/test_dialect_types.py
@@ -47,6 +47,7 @@ def test_defined_types():
     assert sqlalchemy_redshift.dialect.HLLSKETCH \
         is not sqlalchemy.sql.sqltypes.TEXT
 
+
 custom_type_inheritance = [
     (
         sqlalchemy_redshift.dialect.GEOMETRY,

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ deps =
 
 [testenv:lint]
 deps =
-    flake8==2.4.0
+    flake8==4.0.1
     psycopg2
     redshift_connector
 commands=flake8 sqlalchemy_redshift tests


### PR DESCRIPTION
Fix #250. Resolves issues seen for CI doc, lint jobs. Resolution for docs job was pinning jinja2 version to <3.1.0. For lint job, upgrading to `flake8>3.8.0` resolved the issue, so I've bumped to the latest version, `4.0.1`.

Also, resolves lint errors.

## Todos
- [x] MIT compatible
- [ ] Tests
- [ ] Documentation
- [x] Updated CHANGES.rst
