### PR TITLE
Disable redshift_connector dialect statement cache

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 0.8.11 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Disable redshift_connector dialect statement cache (`Pull #257 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/257>`_)
 
 
 0.8.10 (2022-07-21)

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -1097,7 +1097,7 @@ class RedshiftDialect_redshift_connector(RedshiftDialectMixin, PGDialect):
     statement_compiler = RedshiftCompiler_redshift_connector
     execution_ctx_cls = RedshiftExecutionContext_redshift_connector
 
-    supports_statement_cache = True
+    supports_statement_cache = False
     use_setinputsizes = False  # not implemented in redshift_connector
 
     def __init__(self, client_encoding=None, **kwargs):


### PR DESCRIPTION
fixes #244

while I disabled 'supports_statement_cache' attribute for RedshiftDialectMixin, It was incorrectly left enabled for the redshift_connector dialect.

## Todos
- [x] MIT compatible
- [x] Tests
- [ ] Documentation
- [x] Updated CHANGES.rst
