### PR TITLE
Quoting issues

### DIFF
--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -674,8 +674,8 @@ class RedshiftDialectMixin(DefaultDialect):
             fkey_d = {
                 'name': conname,
                 'constrained_columns': constrained_columns,
-                'referred_schema': referred_schema,
-                'referred_table': referred_table,
+                'referred_schema': self.unquote(referred_schema),
+                'referred_table': self.unquote(referred_table),
                 'referred_columns': referred_columns,
             }
             fkeys.append(fkey_d)

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -725,6 +725,22 @@ class RedshiftDialectMixin(DefaultDialect):
         """
         return []
 
+    @staticmethod
+    def unquote(text):
+        if text is None:
+            return None
+        
+        if text.startswith('"') and text.endswith('"'):
+            return text[1:-1]
+        
+        return text
+
+    def get_table_oid(self, connection, table_name, schema=None, **kw):
+        """Unquote table name and schema before getting table oid"""
+        schema = self.unquote(schema)
+        table_name = self.unquote(table_name)
+        return PGDialect.get_table_oid(self, connection, table_name, schema, **kw)
+
     @reflection.cache
     def get_unique_constraints(self, connection, table_name,
                                schema=None, **kw):
@@ -893,6 +909,7 @@ class RedshiftDialectMixin(DefaultDialect):
     def _get_schema_column_info(
         self, connection, schema=None, **kw
     ):
+        schema = self.unquote(schema)
         schema_clause = (
             "AND schema = '{schema}'".format(schema=schema) if schema else ""
         )


### PR DESCRIPTION
Hi,

I've run into the issue described [here](https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/issues/208) and partially fixed [here](https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/228). On my project, it seems like Redshift will not only quote the table name, but also the schema name in some instances, which breaks more stuff than the initial fix addresses.

By unquoting the schema and table names in a couple of extra places, I was able to get my project to autogenerate migrations for the offending schemas without issues. The problems mostly occurred around foreign key resolving, as far as I can tell.

These changes worked for my project, but I'm unfamiliar with inner workings of sqlalchemy dialects, so if there is a better place for unquoting the names please let me know. I've also struggled with coming up with unit tests for these changes, so any advise would be much appreciated.