### PR TITLE
Fix table reflection broken for non-superusers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,8 +2,8 @@
 -------------------
 
 - Override new upstream postgres method that fails against redshift (`Pull #266 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/266>`_)
-- Add CI CFN template, buildpsec, update README
-  (`Pull #268 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/268>`_)
+- Fix table reflection broken for non-superusers
+  (`Pull #276 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/276>`_)
 
 
 0.8.13 (2023-03-28)

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -793,21 +793,18 @@ class RedshiftDialectMixin(DefaultDialect):
     def get_table_oid(self, connection, table_name, schema=None, **kw):
         """Fetch the oid for schema.table_name.
         Return null if not found (external table does not have table oid)"""
-        schema_clause = (
-            "AND schema = '{schema}'".format(schema=schema) if schema else ""
-        )
+        schema_field = '"{schema}".'.format(schema=schema) if schema else ""
 
-        result = connection.execute("""
-                        SELECT table_id
-                        FROM
-                            SVV_TABLE_INFO
-                        WHERE 1
-                            {schema_clause}
-                            AND "table" = '{table_name}';
-                        """.format(
-                                schema_clause=schema_clause,
-                                table_name=table_name)
-                            )
+        result = connection.execute(
+            sa.text(
+                """
+                select '{schema_field}"{table_name}"'::regclass::oid;
+                """.format(
+                    schema_field=schema_field,
+                    table_name=table_name
+                )
+            )
+        )
 
         return result.scalar()
 


### PR DESCRIPTION
fixes #274 
## Todos
- [ ] MIT compatible
- [ ] Tests
- [ ] Documentation
- [ ] Updated CHANGES.rst

testing for this was manual to ensure the database user had the minimum permissions necessary to run these tests. Long term it would be good to move away from use of a database user with elevated permissions in our CI, as it led to our missing this regression. Though doing so will require some changes to CI (i.e. creation of user and granting of permissions needed for testing). I opened #275 in response to this.

I set our integration suite to use the dev db and ran all our reflection tests with the user `test_user`. `test_reflection.py` and `test_reflection_views.py`

```
create user test_user with password 'xxx';
grant select on all tables in schema public to test_user;
grant drop on all tables in schema public to test_user;
grant create on database dev to test_user;
```