### PR TITLE
Fix Broken Reflection for 1.4 FutureEngine

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 - Override new upstream postgres method that fails against redshift (`Pull #266 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/266>`_)
 - Fix table reflection broken for non-superusers
   (`Pull #276 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/276>`_)
+- Fix Broken Reflection for 1.4 FutureEngine
+  (`Pull #277 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/277>`_)
 
 
 0.8.13 (2023-03-28)

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -753,7 +753,7 @@ class RedshiftDialectMixin(DefaultDialect):
         )
         table_oid = 'NULL' if not table_oid else table_oid
 
-        result = connection.execute("""
+        result = connection.execute(sa.text("""
                         SELECT
                             cons.conname as name,
                             pg_get_constraintdef(cons.oid) as src
@@ -762,7 +762,7 @@ class RedshiftDialectMixin(DefaultDialect):
                         WHERE
                             cons.conrelid = {} AND
                             cons.contype = 'c'
-                        """.format(table_oid))
+                        """.format(table_oid)))
         ret = []
         for name, src in result:
             # samples:
@@ -1122,15 +1122,14 @@ class RedshiftDialectMixin(DefaultDialect):
         )
 
         all_columns = defaultdict(list)
-        with connection.connect() as cc:
-            result = cc.execute(sa.text(REFLECTION_SQL.format(
-                schema_clause=schema_clause,
-                table_clause=table_clause
-            )))
+        result = connection.execute(sa.text(REFLECTION_SQL.format(
+            schema_clause=schema_clause,
+            table_clause=table_clause
+        )))
 
-            for col in result:
-                key = RelationKey(col.table_name, col.schema, connection)
-                all_columns[key].append(col)
+        for col in result:
+            key = RelationKey(col.table_name, col.schema, connection)
+            all_columns[key].append(col)
 
         return dict(all_columns)
 

--- a/tests/test_reflection_views.py
+++ b/tests/test_reflection_views.py
@@ -1,6 +1,6 @@
 from sqlalchemy import MetaData, Table, inspect
 from sqlalchemy.schema import CreateTable
-
+import sqlalchemy as sa
 from rs_sqla_test_utils.utils import clean, compile_query
 
 
@@ -13,21 +13,24 @@ def test_view_reflection(redshift_engine):
     table_ddl = "CREATE TABLE my_table (col1 INTEGER, col2 INTEGER)"
     view_query = "SELECT my_table.col1, my_table.col2 FROM my_table"
     view_ddl = "CREATE VIEW my_view AS %s" % view_query
-    conn = redshift_engine.connect()
-    try:
-        conn.execute(table_ddl)
-        conn.execute(view_ddl)
-        insp = inspect(redshift_engine)
-        view_definition = insp.get_view_definition('my_view')
-        assert clean(
-            compile_query(view_definition, redshift_engine.dialect)
-        ) == clean(view_query)
-        view = Table('my_view', MetaData(),
-                     autoload=True, autoload_with=redshift_engine)
-        assert(len(view.columns) == 2)
-    finally:
-        conn.execute('DROP TABLE IF EXISTS my_table CASCADE')
-        conn.execute('DROP VIEW IF EXISTS my_view CASCADE')
+
+    with redshift_engine.connect() as conn:
+        try:
+            conn.execute(sa.text(table_ddl))
+            conn.execute(sa.text(view_ddl))
+            conn.execute(sa.text("COMMIT"))
+            insp = inspect(redshift_engine)
+            view_definition = insp.get_view_definition('my_view')
+            assert clean(
+                compile_query(view_definition, redshift_engine.dialect)
+            ) == clean(view_query)
+            view = Table('my_view', MetaData(),
+                         autoload=True, autoload_with=redshift_engine)
+            assert(len(view.columns) == 2)
+        finally:
+            conn.execute(sa.text('DROP TABLE IF EXISTS my_table CASCADE'))
+            conn.execute(sa.text('DROP VIEW IF EXISTS my_view CASCADE'))
+            conn.execute(sa.text("COMMIT"))
 
 
 def test_late_binding_view_reflection(redshift_engine):
@@ -35,20 +38,23 @@ def test_late_binding_view_reflection(redshift_engine):
     view_query = "SELECT my_table.col1, my_table.col2 FROM public.my_table"
     view_ddl = ("CREATE VIEW my_late_view AS "
                 "%s WITH NO SCHEMA BINDING" % view_query)
-    conn = redshift_engine.connect()
-    try:
-        conn.execute(table_ddl)
-        conn.execute(view_ddl)
-        insp = inspect(redshift_engine)
-        view_definition = insp.get_view_definition('my_late_view')
 
-        # Redshift returns the entire DDL for late binding views.
-        assert clean(
-            compile_query(view_definition, redshift_engine.dialect)
-        ) == clean(view_ddl)
-        view = Table('my_late_view', MetaData(),
-                     autoload=True, autoload_with=redshift_engine)
-        assert(len(view.columns) == 2)
-    finally:
-        conn.execute('DROP TABLE IF EXISTS my_table CASCADE')
-        conn.execute('DROP VIEW IF EXISTS my_late_view CASCADE')
+    with redshift_engine.connect() as conn:
+        try:
+            conn.execute(sa.text(table_ddl))
+            conn.execute(sa.text(view_ddl))
+            conn.execute(sa.text("COMMIT"))
+            insp = inspect(redshift_engine)
+            view_definition = insp.get_view_definition('my_late_view')
+
+            # Redshift returns the entire DDL for late binding views.
+            assert clean(
+                compile_query(view_definition, redshift_engine.dialect)
+            ) == clean(view_ddl)
+            view = Table('my_late_view', MetaData(),
+                         autoload=True, autoload_with=redshift_engine)
+            assert(len(view.columns) == 2)
+        finally:
+            conn.execute(sa.text('DROP TABLE IF EXISTS my_table CASCADE'))
+            conn.execute(sa.text('DROP VIEW IF EXISTS my_late_view CASCADE'))
+            conn.execute(sa.text('COMMIT'))


### PR DESCRIPTION
## Todos
- [ ] MIT compatible
- [ ] Tests
- [ ] Documentation
- [ ] Updated CHANGES.rst


fix #269

removes direct reference to `connection.connect() ` in reflection code which breaks with 1.4 FutureEngine. instead, uses `connection.execute` to avoid branching connections.

modifies test suite for compatability with 1.4 FutureEngine by moving to using `sa.text` and accommodating new behavior around autocommit in 1.4 FutureEngine. Some of this should aid future work towards #264.

I ran these changes through our CI, and manually ran sqlalchemy1.4 targets with FutureEngine enabled to confirm resolution. Prior to this fix, I could consistently repro with our test suite and sqlalchemy1.4 with FutureEngine. 