### PR TITLE
Fix invalid escape sequence warnings

### DIFF
--- a/sqlalchemy_redshift/commands.py
+++ b/sqlalchemy_redshift/commands.py
@@ -23,14 +23,14 @@ from sqlalchemy.sql import expression as sa_expression
 # The pattern of IAM role ARNs can be found here:
 #   http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-iam
 
-ACCESS_KEY_ID_RE = re.compile('[A-Z0-9]{20}')
-SECRET_ACCESS_KEY_RE = re.compile('[A-Za-z0-9/+=]{40}')
-TOKEN_RE = re.compile('[A-Za-z0-9/+=]+')
+ACCESS_KEY_ID_RE = re.compile(r'[A-Z0-9]{20}')
+SECRET_ACCESS_KEY_RE = re.compile(r'[A-Za-z0-9/+=]{40}')
+TOKEN_RE = re.compile(r'[A-Za-z0-9/+=]+')
 AWS_PARTITIONS = frozenset({'aws', 'aws-cn', 'aws-us-gov'})
-AWS_ACCOUNT_ID_RE = re.compile('[0-9]{12}')
-IAM_ROLE_NAME_RE = re.compile('[A-Za-z0-9+=,.@\-_]{1,64}')  # noqa
-IAM_ROLE_ARN_RE = re.compile('arn:(aws|aws-cn|aws-us-gov):iam::'
-                             '[0-9]{12}:role/[A-Za-z0-9+=,.@\-_]{1,64}')  # noqa
+AWS_ACCOUNT_ID_RE = re.compile(r'[0-9]{12}')
+IAM_ROLE_NAME_RE = re.compile(r'[A-Za-z0-9+=,.@\-_]{1,64}')
+IAM_ROLE_ARN_RE = re.compile(r'arn:(aws|aws-cn|aws-us-gov):iam::'
+                             r'[0-9]{12}:role/[A-Za-z0-9+=,.@\-_]{1,64}')
 
 
 def _process_aws_credentials(access_key_id=None, secret_access_key=None,


### PR DESCRIPTION
Summary: Python starts warning in 3.6+ about invalid escape sequences in strings. These regexes currently trigger that warning, but we can fix that easily by converting them to raw strings instead. Only some of these strings currently cause the invalid escape sequence warning, but since they are all regexes it is reasonable to convert all of them to raw strings.

I also removed the `# noqa` comments since I think they were added because of this issue.

Test Plan: For each string changed, tested that '$str' == r'$str' in the python shell

## Todos
- [ ] MIT compatible
- [ ] Tests
- [ ] Documentation
- [ ] Updated CHANGES.rst
