### PR TITLE
Fix deprecated Python string literal escape sequence

### DIFF
--- a/sqlalchemy_redshift/commands.py
+++ b/sqlalchemy_redshift/commands.py
@@ -28,9 +28,9 @@ SECRET_ACCESS_KEY_RE = re.compile('[A-Za-z0-9/+=]{40}')
 TOKEN_RE = re.compile('[A-Za-z0-9/+=]+')
 AWS_PARTITIONS = frozenset({'aws', 'aws-cn', 'aws-us-gov'})
 AWS_ACCOUNT_ID_RE = re.compile('[0-9]{12}')
-IAM_ROLE_NAME_RE = re.compile('[A-Za-z0-9+=,.@\-_]{1,64}')  # noqa
+IAM_ROLE_NAME_RE = re.compile('[A-Za-z0-9+=,.@\\-_]{1,64}')
 IAM_ROLE_ARN_RE = re.compile('arn:(aws|aws-cn|aws-us-gov):iam::'
-                             '[0-9]{12}:role/[A-Za-z0-9+=,.@\-_]{1,64}')  # noqa
+                             '[0-9]{12}:role/[A-Za-z0-9+=,.@\\-_]{1,64}')
 
 
 def _process_aws_credentials(access_key_id=None, secret_access_key=None,


### PR DESCRIPTION
These regular expressions are intending to "escape" the `-` so that it's not treated as a range inside of the `[ ... ]` regex character class-- but Python sees this as a string literal containing the escape sequence `\-`.

Starting in Python 3.12, this is a hard error, while 3.11 produces a deprecation warning. The correct syntax uses `\\-`.

I assume the `# noqa` comments were suppressing a static check which identified this as a problem.

This PR doesn't cause any change in behavior, except for suppressing the `SyntaxError`/`Warning` generated by the invalid string literal.

## Todos
- [x] MIT compatible
- [x] Tests
- [x] Documentation
- [x] Updated CHANGES.rst
