### PR TITLE
Add support for iceberg string and binary types

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,8 @@
 0.8.15 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add support for Iceberg string and binary types
+  (`Pull #297 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/297>`_)
 
 
 0.8.14 (2023-04-07)

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -413,14 +413,14 @@ class HLLSKETCH(RedshiftTypeEngine, sa.dialects.postgresql.TEXT):
         return dbapi.HLLSKETCH
 
 
-class IcebergString(sa.types.TypeDecorator):
+class ICEBERG_STRING(sa.types.TypeDecorator):
     impl = sa.types.String
 
     def load_dialect_impl(self, dialect):
         return sa.dialects.postgresql.VARCHAR(length=MAX_VARCHAR_LENGTH)
 
 
-class IcebergBinary(sa.types.TypeDecorator):
+class ICEBERG_BINARY(sa.types.TypeDecorator):
     impl = sa.types.LargeBinary
 
     def process_bind_param(self, value, dialect):
@@ -465,8 +465,8 @@ REDSHIFT_ISCHEMA_NAMES = {
     "timestamp with time zone": TIMESTAMPTZ,
     "hllsketch": HLLSKETCH,
     # iceberg types
-    "string": IcebergString,
-    "binary": IcebergBinary,
+    "string": ICEBERG_STRING,
+    "binary": ICEBERG_BINARY,
 }
 
 

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -416,13 +416,20 @@ class HLLSKETCH(RedshiftTypeEngine, sa.dialects.postgresql.TEXT):
 class ICEBERG_STRING(sa.types.TypeDecorator):
     impl = sa.types.String
 
+    @property
+    def python_type(self):
+        return str
+
     def load_dialect_impl(self, dialect):
         return sa.dialects.postgresql.VARCHAR(length=MAX_VARCHAR_LENGTH)
-
 
 class ICEBERG_BINARY(sa.types.TypeDecorator):
     impl = sa.types.LargeBinary
 
+    @property
+    def python_type(self):
+        return bytes
+ 
     def process_bind_param(self, value, dialect):
         if value is None:
             return value

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -422,7 +422,7 @@ class IcebergString(sa.types.TypeDecorator):
 
 class IcebergBinary(sa.types.TypeDecorator):
     impl = sa.types.LargeBinary
- 
+
     def process_bind_param(self, value, dialect):
         if value is None:
             return value
@@ -449,7 +449,10 @@ class IcebergBinary(sa.types.TypeDecorator):
                 encoding = getattr(dialect, 'encoding', 'utf-8')
                 return value.encode(encoding)
 
-            raise TypeError(f"Unexpected type for value in result_processor.process: {type(value)}")
+            raise TypeError(
+                "Unexpected type for value in result_processor.process: ",
+                type(value)
+            )
 
         return process
 

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -414,6 +414,13 @@ class HLLSKETCH(RedshiftTypeEngine, sa.dialects.postgresql.TEXT):
 
 
 class ICEBERG_STRING(sa.types.TypeDecorator):
+    """
+    A custom SQLAlchemy type decorator for representing iceberg strings.
+
+    This type decorator is used to represent iceberg strings in a
+    Redshift/PostgreSQL database using SQLAlchemy.
+    """
+
     impl = sa.types.String
 
     @property
@@ -423,13 +430,22 @@ class ICEBERG_STRING(sa.types.TypeDecorator):
     def load_dialect_impl(self, dialect):
         return sa.dialects.postgresql.VARCHAR(length=MAX_VARCHAR_LENGTH)
 
+
 class ICEBERG_BINARY(sa.types.TypeDecorator):
+    """
+    A custom SQLAlchemy type decorator for storing/querying binary data in an
+    Iceberg database.
+
+    This type decorator is used to represent iceberg binary data in a
+    Redshift/PostgreSQL database using SQLAlchemy.
+    """
+
     impl = sa.types.LargeBinary
 
     @property
     def python_type(self):
         return bytes
- 
+
     def process_bind_param(self, value, dialect):
         if value is None:
             return value

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -290,6 +290,9 @@ REFLECTION_SQL = """\
     """
 
 
+MAX_VARCHAR_LENGTH = 65535
+
+
 class RedshiftTypeEngine(TypeEngine):
 
     def _default_dialect(self, default=None):
@@ -410,6 +413,47 @@ class HLLSKETCH(RedshiftTypeEngine, sa.dialects.postgresql.TEXT):
         return dbapi.HLLSKETCH
 
 
+class IcebergString(sa.types.TypeDecorator):
+    impl = sa.types.String
+
+    def load_dialect_impl(self, dialect):
+        return sa.dialects.postgresql.VARCHAR(length=MAX_VARCHAR_LENGTH)
+
+
+class IcebergBinary(sa.types.TypeDecorator):
+    impl = sa.types.LargeBinary
+ 
+    def process_bind_param(self, value, dialect):
+        if value is None:
+            return value
+
+        encoding = getattr(dialect, 'encoding', 'utf-8')
+
+        if isinstance(value, bytes):
+            return value
+
+        if isinstance(value, str):
+            return value.encode(encoding)
+
+        return value
+
+    def result_processor(self, dialect, coltype):
+        def process(value):
+            if value is None:
+                return value
+
+            if isinstance(value, bytes):
+                return value
+
+            if isinstance(value, str):
+                encoding = getattr(dialect, 'encoding', 'utf-8')
+                return value.encode(encoding)
+
+            raise TypeError(f"Unexpected type for value in result_processor.process: {type(value)}")
+
+        return process
+
+
 # Mapping for database schema inspection of Amazon Redshift datatypes
 REDSHIFT_ISCHEMA_NAMES = {
     "geometry": GEOMETRY,
@@ -417,6 +461,9 @@ REDSHIFT_ISCHEMA_NAMES = {
     "time with time zone": TIMETZ,
     "timestamp with time zone": TIMESTAMPTZ,
     "hllsketch": HLLSKETCH,
+    # iceberg types
+    "string": IcebergString,
+    "binary": IcebergBinary,
 }
 
 

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -415,9 +415,7 @@ class HLLSKETCH(RedshiftTypeEngine, sa.dialects.postgresql.TEXT):
 
 class ICEBERG_STRING(sa.types.TypeDecorator):
     """
-    A custom SQLAlchemy type decorator for representing iceberg strings.
-
-    This type decorator is used to represent iceberg strings in a
+    ICEBERG_STRING is used to represent iceberg strings in a
     Redshift/PostgreSQL database using SQLAlchemy.
     """
 
@@ -433,10 +431,7 @@ class ICEBERG_STRING(sa.types.TypeDecorator):
 
 class ICEBERG_BINARY(sa.types.TypeDecorator):
     """
-    A custom SQLAlchemy type decorator for storing/querying binary data in an
-    Iceberg database.
-
-    This type decorator is used to represent iceberg binary data in a
+    ICEBERG_BINARY is used to represent iceberg binary data in a
     Redshift/PostgreSQL database using SQLAlchemy.
     """
 

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -427,12 +427,11 @@ class ICEBERG_BINARY(sa.types.TypeDecorator):
         if value is None:
             return value
 
-        encoding = getattr(dialect, 'encoding', 'utf-8')
-
         if isinstance(value, bytes):
             return value
 
         if isinstance(value, str):
+            encoding = getattr(dialect, 'encoding', 'utf-8')
             return value.encode(encoding)
 
         return value

--- a/tests/test_column_loading.py
+++ b/tests/test_column_loading.py
@@ -6,7 +6,7 @@ from sqlalchemy.types import NullType, VARCHAR
 
 from sqlalchemy_redshift.dialect import (
     RedshiftDialect_psycopg2, RedshiftDialect_psycopg2cffi,
-    IcebergString, IcebergBinary
+    ICEBERG_STRING, ICEBERG_BINARY
 )
 
 sa_version = Version(sa.__version__)
@@ -61,7 +61,7 @@ class TestColumnReflection(TestCase):
                 comment='test column',
                 identity=None
             )
-            assert isinstance(iceberg_string_info['type'], IcebergString)
+            assert isinstance(iceberg_string_info['type'], ICEBERG_STRING)
 
             iceberg_binary_info = dialect._get_column_info(
                 name='Iceberg Binary Column',
@@ -75,4 +75,4 @@ class TestColumnReflection(TestCase):
                 comment='test column',
                 identity=None
             )
-            assert isinstance(iceberg_binary_info['type'], IcebergBinary)
+            assert isinstance(iceberg_binary_info['type'], ICEBERG_BINARY)

--- a/tests/test_column_loading.py
+++ b/tests/test_column_loading.py
@@ -5,7 +5,8 @@ import sqlalchemy as sa
 from sqlalchemy.types import NullType, VARCHAR
 
 from sqlalchemy_redshift.dialect import (
-    RedshiftDialect_psycopg2, RedshiftDialect_psycopg2cffi
+    RedshiftDialect_psycopg2, RedshiftDialect_psycopg2cffi,
+    IcebergString, IcebergBinary
 )
 
 sa_version = Version(sa.__version__)
@@ -47,3 +48,31 @@ class TestColumnReflection(TestCase):
                 identity=None
             )
             assert isinstance(varchar_info['type'], VARCHAR)
+
+            iceberg_string_info = dialect._get_column_info(
+                name='Iceberg String Column',
+                format_type='string',
+                default=None,
+                notnull=False,
+                domains={},
+                enums=[],
+                schema='default',
+                encode='',
+                comment='test column',
+                identity=None
+            )
+            assert isinstance(iceberg_string_info['type'], IcebergString)
+
+            iceberg_binary_info = dialect._get_column_info(
+                name='Iceberg Binary Column',
+                format_type='binary',
+                default=None,
+                notnull=False,
+                domains={},
+                enums=[],
+                schema='default',
+                encode='',
+                comment='test column',
+                identity=None
+            )
+            assert isinstance(iceberg_binary_info['type'], IcebergBinary)


### PR DESCRIPTION
### Description

This pull request introduces support for two new column types from the Iceberg table format: `string` and `binary`. These types are increasingly common in data warehousing scenarios, and their inclusion in `sqlalchemy-redshift` will enhance compatibility with Iceberg tables and improve the user experience for those working with Redshift and Iceberg.

> This PR is specifically tailored to add/improve interactions with Spectrum tables in Iceberg format.

### Changes

- Added a new custom type `ICEBERG_STRING` that maps Iceberg's `string` type to Redshift/Postgre's `VARCHAR` type with a default max length.
- Added a new custom type `ICEBERG_BINARY` that maps Iceberg's `binary` type to SQLAlchemy's `LargeBinary` type.
- Included unit tests 
- Updated the documentation to reflect the new type support.

### Motivation

As Iceberg tables become more prevalent, it is important for `sqlalchemy-redshift` to evolve and support the diverse data types used in these tables. The lack of native support for `string` and `binary` types can lead to challenges when querying Iceberg tables, and this PR aims to address those challenges.

### Backward Compatibility

These changes are fully backward-compatible as they introduce new types without altering the existing functionality of the dialect.

### Additional Notes

I look forward to feedback from the maintainers and community on this PR. If there are any additional changes or enhancements needed, I am open to discussion and collaboration.

<img width="576" alt="image" src="https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/assets/2353242/9e8c8b5b-2f90-4e8f-b49c-0261a151d3e2">

### Todos
- [x] MIT compatible
- [x] Tests
- [x] Documentation
- [x] Updated CHANGES.rst
