### PR TITLE
add NUMERIC type

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,8 @@
 0.8.15 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Added Numeric type support
+  (`Pull #298 <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/298>`_)
 
 
 0.8.14 (2023-04-07)

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -21,7 +21,7 @@ from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.sql.expression import (BinaryExpression, BooleanClauseList,
                                        Delete)
 from sqlalchemy.sql.type_api import TypeEngine
-from sqlalchemy.types import (BIGINT, BOOLEAN, CHAR, DATE, DECIMAL, INTEGER,
+from sqlalchemy.types import (BIGINT, BOOLEAN, CHAR, DATE, DECIMAL,NUMERIC, INTEGER,
                               REAL, SMALLINT, TIMESTAMP, VARCHAR, NullType)
 
 from .commands import (AlterTableAppendCommand, Compression, CopyCommand,

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -53,6 +53,7 @@ else:
 # with its __all__ collection
 # https://docs.sqlalchemy.org/en/13/core/type_basics.html#vendor-specific-types
 __all__ = (
+    'NUMERIC',
     'SMALLINT',
     'INTEGER',
     'BIGINT',

--- a/tests/test_dialect_types.py
+++ b/tests/test_dialect_types.py
@@ -31,8 +31,8 @@ def test_defined_types():
         is sqlalchemy.sql.sqltypes.TIMESTAMP
     assert sqlalchemy_redshift.dialect.DOUBLE_PRECISION \
         is sqlalchemy.dialects.postgresql.DOUBLE_PRECISION
-    assert sqlalchemy_redshift.dialect.Numeric \
-        is sqlalchemy.sql.sqltypes.Numeric
+    assert sqlalchemy_redshift.dialect.NUMERIC \
+        is sqlalchemy.sql.sqltypes.NUMERIC
 
     assert sqlalchemy_redshift.dialect.GEOMETRY \
         is not sqlalchemy.sql.sqltypes.TEXT

--- a/tests/test_dialect_types.py
+++ b/tests/test_dialect_types.py
@@ -31,6 +31,8 @@ def test_defined_types():
         is sqlalchemy.sql.sqltypes.TIMESTAMP
     assert sqlalchemy_redshift.dialect.DOUBLE_PRECISION \
         is sqlalchemy.dialects.postgresql.DOUBLE_PRECISION
+    assert sqlalchemy_redshift.dialect.Numeric \
+        is sqlalchemy.sql.sqltypes.Numeric
 
     assert sqlalchemy_redshift.dialect.GEOMETRY \
         is not sqlalchemy.sql.sqltypes.TEXT


### PR DESCRIPTION
sqlalchemy-redshift cannot understand Numeric type but it was added in sqlalchemy
## Todos
- [x] MIT compatible
- [x] Tests
- [x] Documentation
- [x] Updated CHANGES.rst
