### PR TITLE
Override cte_follows_insert to True

### DIFF
--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -666,6 +666,7 @@ class RedshiftDialectMixin(DefaultDialect):
 
     name = 'redshift'
     max_identifier_length = 127
+    cte_follows_insert = True
 
     statement_compiler = RedshiftCompiler
     ddl_compiler = RedshiftDDLCompiler

--- a/tests/test_insert_stmt.py
+++ b/tests/test_insert_stmt.py
@@ -1,0 +1,100 @@
+import sqlalchemy as sa
+from packaging.version import Version
+
+from rs_sqla_test_utils.utils import clean, compile_query
+
+sa_version = Version(sa.__version__)
+
+
+meta = sa.MetaData()
+
+customers = sa.Table(
+    'customers', meta,
+    sa.Column('id', sa.Integer, primary_key=True, autoincrement=False),
+    sa.Column('first_name', sa.String(128)),
+    sa.Column('last_name', sa.String(128)),
+    sa.Column('email', sa.String(255))
+)
+
+
+def test_insert_values(stub_redshift_dialect):
+    insert_stmt = customers.insert().values(
+        (1, "Firstname", "Lastname", "firstname.lastname@example.com")
+    )
+
+    expected = """
+    INSERT INTO customers (id, first_name, last_name, email)
+    VALUES
+        (1, 'Firstname', 'Lastname', 'firstname.lastname@example.com')
+    """
+
+    assert clean(compile_query(insert_stmt, stub_redshift_dialect)) == \
+        clean(expected)
+
+    insert_stmt = customers.insert().values([
+        (1, "Firstname", "Lastname", "firstname.lastname@example.com"),
+        (2, "Firstname2", "Lastname2", "firstname2.lastname2@example.com"),
+    ])
+    expected = """
+    INSERT INTO customers (id, first_name, last_name, email)
+    VALUES
+        (1, 'Firstname', 'Lastname', 'firstname.lastname@example.com'),
+        (2, 'Firstname2', 'Lastname2', 'firstname2.lastname2@example.com')
+    """
+
+    assert clean(compile_query(insert_stmt, stub_redshift_dialect)) == \
+        clean(expected)
+
+
+def test_insert_from_select(stub_redshift_dialect):
+    select_expr = sa.select(customers.columns)
+    if sa_version >= Version('1.4.0'):
+        columns = select_expr.selected_columns
+    else:
+        columns = select_expr.columns
+    
+    insert_stmt = customers.insert().from_select(columns, select_expr)
+
+    expected = """
+    INSERT INTO customers (id, first_name, last_name, email)
+        SELECT
+            customers.id,
+            customers.first_name,
+            customers.last_name,
+            customers.email
+        FROM customers
+    """
+
+    assert clean(compile_query(insert_stmt, stub_redshift_dialect)) == \
+        clean(expected)
+
+
+def test_insert_from_cte(stub_redshift_dialect):
+    cte_expr = sa.select(customers.columns).cte("cte")
+
+    select_expr = sa.select(cte_expr.columns).where(
+        cte_expr.columns.last_name == "Lastname"
+    )
+    if sa_version >= Version('1.4.0'):
+        columns = select_expr.selected_columns
+    else:
+        columns = select_expr.columns
+
+    insert_stmt = customers.insert().from_select(columns, select_expr)
+
+    expected = """
+    INSERT INTO customers (id, first_name, last_name, email)
+    WITH cte AS
+        (SELECT
+            customers.id AS id,
+            customers.first_name AS first_name,
+            customers.last_name AS last_name,
+            customers.email AS email
+        FROM customers)
+    SELECT cte.id, cte.first_name, cte.last_name, cte.email
+    FROM cte
+    WHERE cte.last_name = 'Lastname'
+    """
+
+    assert clean(compile_query(insert_stmt, stub_redshift_dialect)) == \
+        clean(expected)


### PR DESCRIPTION
## Todos
- [x] MIT compatible
- [x] Tests
- [ ] Documentation
- [ ] Updated CHANGES.rst

Resolves: https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/issues/154 which is labeled as help wanted

* Set `cte_follows_insert` to True, this causes CTEs to be rendered after INSERT statements.

Without this change, the following code
``` python
import sqlalchemy as sa
meta = sa.MetaData()

customers = sa.Table(
    'customers', meta,
    sa.Column('id', sa.Integer, primary_key=True, autoincrement=False),
    sa.Column('first_name', sa.String(128)),
    sa.Column('last_name', sa.String(128)),
    sa.Column('email', sa.String(255))
)

cte_expr = sa.select(customers.columns).cte("cte")
insert_stmt = customers.insert().from_select(cte_expr.columns, cte_expr)
print(str(insert_stmt.compile(dialect=engine.dialect, compile_kwargs={'literal_binds': True})))
```

Renders the insert statement after defining the CTE. Which is not syntactically valid in Redshift.
```
WITH cte AS
    (SELECT
        customers.id AS id,
        customers.first_name AS first_name,
        customers.last_name AS last_name,
        customers.email AS email
    FROM customers)
INSERT INTO customers (id, first_name, last_name, email)
SELECT cte.id, cte.first_name, cte.last_name, cte.email
FROM cte
```

After overriding this flag the statement is rendered correctly:
```
INSERT INTO customers (id, first_name, last_name, email)
WITH cte AS
    (SELECT
        customers.id AS id,
        customers.first_name AS first_name,
        customers.last_name AS last_name,
        customers.email AS email
    FROM customers)
SELECT cte.id, cte.first_name, cte.last_name, cte.email
FROM cte
```

Can also close https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/107 which was implemented before cte_follows_insert existed

