### PR TITLE
fix: Fixes for reflection in `SQLAlchemy` 2.0  

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 0.8.15 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix SQLAlchemy V2 support (https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/293)
 
 
 0.8.14 (2023-04-07)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ history = open('CHANGES.rst').read().replace('.. :changelog:', '')
 
 setup(
     name='sqlalchemy-redshift',
-    version='0.8.15.dev0',
+    version='0.8.16.dev0',
     description='Amazon Redshift Dialect for sqlalchemy',
     long_description=readme + '\n\n' + history,
     long_description_content_type='text/x-rst',
@@ -21,7 +21,7 @@ setup(
     install_requires=[
         # requires sqlalchemy.sql.base.DialectKWArgs.dialect_options, new in
         # version 0.9.2
-        'SQLAlchemy>=0.9.2,<2.0.0',
+        'SQLAlchemy>=0.9.2,<3.0.0',
         'packaging',
     ],
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ history = open('CHANGES.rst').read().replace('.. :changelog:', '')
 
 setup(
     name='sqlalchemy-redshift',
-    version='0.8.16.dev0',
+    version='0.8.15.dev0',
     description='Amazon Redshift Dialect for sqlalchemy',
     long_description=readme + '\n\n' + history,
     long_description_content_type='text/x-rst',

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -1368,9 +1368,8 @@ class RedshiftDialect_redshift_connector(RedshiftDialectMixin, PGDialect):
         fns = []
 
         def on_connect(conn):
-            from sqlalchemy import util
             from sqlalchemy.sql.elements import quoted_name
-            conn.py_types[quoted_name] = conn.py_types[util.text_type]
+            conn.py_types[quoted_name] = conn.py_types[str]
 
         fns.append(on_connect)
 

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -8,7 +8,8 @@ import pkg_resources
 import sqlalchemy as sa
 from packaging.version import Version
 from sqlalchemy import inspect
-from sqlalchemy.dialects.postgresql import DOUBLE_PRECISION
+from sqlalchemy.dialects.postgresql import DOMAIN, DOUBLE_PRECISION, ENUM
+from sqlalchemy.dialects.postgresql.base import util
 from sqlalchemy.dialects.postgresql.base import (PGCompiler, PGDDLCompiler,
                                                  PGDialect, PGExecutionContext,
                                                  PGIdentifierPreparer,
@@ -21,6 +22,7 @@ from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.sql.expression import (BinaryExpression, BooleanClauseList,
                                        Delete)
 from sqlalchemy.sql.type_api import TypeEngine
+from sqlalchemy.sql import sqltypes
 from sqlalchemy.types import (BIGINT, BOOLEAN, CHAR, DATE, DECIMAL, INTEGER,
                               REAL, SMALLINT, TIMESTAMP, VARCHAR, NullType)
 
@@ -29,6 +31,8 @@ from .commands import (AlterTableAppendCommand, Compression, CopyCommand,
                        RefreshMaterializedView, UnloadFromSelect)
 from .ddl import (CreateMaterializedView, DropMaterializedView,
                   get_table_attributes)
+from typing import List
+from sqlalchemy.engine.reflection import ReflectionDefaults
 
 sa_version = Version(sa.__version__)
 logger = getLogger(__name__)
@@ -467,6 +471,9 @@ class RelationKey(namedtuple('RelationKey', ('name', 'schema'))):
 
 class RedshiftCompiler(PGCompiler):
 
+    def visit_array_agg_func(self, fn, **kw):
+        return "LISTAGG(%s)" % self.function_argspec(fn, **kw)
+
     def visit_now_func(self, fn, **kw):
         return "SYSDATE"
 
@@ -710,6 +717,64 @@ class RedshiftDialectMixin(DefaultDialect):
             **super(RedshiftDialectMixin, self).ischema_names,
             **REDSHIFT_ISCHEMA_NAMES
         }
+    def get_multi_indexes(self, connection, **kw):
+        return self._default_multi_reflect(self.get_indexes, connection, **kw)
+
+    def get_multi_foreign_keys(self, connection, **kw):
+        return self._default_multi_reflect(self.get_foreign_keys, connection, **kw)
+
+    def get_multi_pk_constraint(self, connection, **kw):
+        return self._default_multi_reflect(self.get_pk_constraint, connection, **kw)
+
+    def get_multi_unique_constraints(self, connection, **kw):
+        return self._default_multi_reflect(self.get_unique_constraints, connection, **kw)
+
+    def get_multi_columns(self, connection, **kw):
+        return self._default_multi_reflect(self.get_columns, connection, **kw)
+
+    def get_temp_table_names(self, *args, **kwargs) -> List[str]:
+        return []
+
+    # Copied from SQLAlchemy 1.4.0
+    # https://github.com/sqlalchemy/sqlalchemy/blob/rel_1_4_54/lib/sqlalchemy/dialects/postgresql/base.py#L4741-L4778
+    def _load_domains(self, connection):
+        # Load data types for domains:
+        SQL_DOMAINS = """
+            SELECT t.typname as "name",
+               pg_catalog.format_type(t.typbasetype, t.typtypmod) as "attype",
+               not t.typnotnull as "nullable",
+               t.typdefault as "default",
+               pg_catalog.pg_type_is_visible(t.oid) as "visible",
+               n.nspname as "schema"
+            FROM pg_catalog.pg_type t
+               LEFT JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
+            WHERE t.typtype = 'd'
+        """
+
+        s = sa.text(SQL_DOMAINS)
+        c = connection.execution_options(future_result=True).execute(s)
+
+        domains = {}
+        for domain in c.mappings():
+            domain = domain
+            # strip (30) from character varying(30)
+            attype = re.search(r"([^\(]+)", domain["attype"]).group(1)
+            # 'visible' just means whether or not the domain is in a
+            # schema that's on the search path -- or not overridden by
+            # a schema with higher precedence. If it's not visible,
+            # it will be prefixed with the schema-name when it's used.
+            if domain["visible"]:
+                key = (domain["name"],)
+            else:
+                key = (domain["schema"], domain["name"])
+
+            domains[key] = {
+                "attype": attype,
+                "nullable": domain["nullable"],
+                "default": domain["default"],
+            }
+
+        return domains
 
     @reflection.cache
     def get_columns(self, connection, table_name, schema=None, **kw):
@@ -725,7 +790,7 @@ class RedshiftDialectMixin(DefaultDialect):
         domains = self._domains
         columns = []
         for col in cols:
-            column_info = self._get_column_info(
+            column_info = self._get_redshift_column_info(
                 name=col.name, format_type=col.format_type,
                 default=col.default, notnull=col.notnull, domains=domains,
                 enums=[], schema=col.schema, encode=col.encode,
@@ -980,7 +1045,193 @@ class RedshiftDialectMixin(DefaultDialect):
                 relation_names.append(key.name)
         return relation_names
 
-    def _get_column_info(self, *args, **kwargs):
+
+    # Copied from SQLAlchemy 1.4
+    # https://github.com/sqlalchemy/sqlalchemy/blob/rel_1_4_54/lib/sqlalchemy/dialects/postgresql/base.py#L4008C4-L4189C27
+    def _get_column_info(
+        self,
+        name,
+        format_type,
+        default,
+        notnull,
+        domains,
+        enums,
+        schema,
+        comment,
+        generated,
+        identity,
+    ):
+        def _handle_array_type(attype):
+            return (
+                # strip '[]' from integer[], etc.
+                re.sub(r"\[\]$", "", attype),
+                attype.endswith("[]"),
+            )
+
+        if format_type is None:
+            no_format_type = True
+            attype = format_type = "no format_type()"
+            is_array = False
+        else:
+            no_format_type = False
+
+            # strip (*) from character varying(5), timestamp(5)
+            # with time zone, geometry(POLYGON), etc.
+            attype = re.sub(r"\(.*\)", "", format_type)
+
+            # strip '[]' from integer[], etc. and check if an array
+            attype, is_array = _handle_array_type(attype)
+
+        # strip quotes from case sensitive enum or domain names
+        enum_or_domain_key = tuple(util.quoted_token_parser(attype))
+
+        nullable = not notnull
+
+        charlen = re.search(r"\(([\d,]+)\)", format_type)
+        if charlen:
+            charlen = charlen.group(1)
+        args = re.search(r"\((.*)\)", format_type)
+        if args and args.group(1):
+            args = tuple(re.split(r"\s*,\s*", args.group(1)))
+        else:
+            args = ()
+        kwargs = {}
+
+        if attype == "numeric":
+            if charlen:
+                prec, scale = charlen.split(",")
+                args = (int(prec), int(scale))
+            else:
+                args = ()
+        elif attype == "double precision":
+            args = (53,)
+        elif attype == "integer":
+            args = ()
+        elif attype in ("timestamp with time zone", "time with time zone"):
+            kwargs["timezone"] = True
+            if charlen:
+                kwargs["precision"] = int(charlen)
+            args = ()
+        elif attype in (
+            "timestamp without time zone",
+            "time without time zone",
+            "time",
+        ):
+            kwargs["timezone"] = False
+            if charlen:
+                kwargs["precision"] = int(charlen)
+            args = ()
+        elif attype == "bit varying":
+            kwargs["varying"] = True
+            if charlen:
+                args = (int(charlen),)
+            else:
+                args = ()
+        elif attype.startswith("interval"):
+            field_match = re.match(r"interval (.+)", attype, re.I)
+            if charlen:
+                kwargs["precision"] = int(charlen)
+            if field_match:
+                kwargs["fields"] = field_match.group(1)
+            attype = "interval"
+            args = ()
+        elif charlen:
+            args = (int(charlen),)
+
+        while True:
+            # looping here to suit nested domains
+            if attype in self.ischema_names:
+                coltype = self.ischema_names[attype]
+                break
+            elif enum_or_domain_key in enums:
+                enum = enums[enum_or_domain_key]
+                coltype = ENUM
+                kwargs["name"] = enum["name"]
+                if not enum["visible"]:
+                    kwargs["schema"] = enum["schema"]
+                args = tuple(enum["labels"])
+                break
+            elif enum_or_domain_key in domains:
+                domain = domains[enum_or_domain_key]
+                attype = domain["attype"]
+                attype, is_array = _handle_array_type(attype)
+                # strip quotes from case sensitive enum or domain names
+                enum_or_domain_key = tuple(util.quoted_token_parser(attype))
+                # A table can't override a not null on the domain,
+                # but can override nullable
+                nullable = nullable and domain["nullable"]
+                if domain["default"] and not default:
+                    # It can, however, override the default
+                    # value, but can't set it to null.
+                    default = domain["default"]
+                continue
+            else:
+                coltype = None
+                break
+
+        if coltype:
+            coltype = coltype(*args, **kwargs)
+            if is_array:
+                coltype = self.ischema_names["_array"](coltype)
+        elif no_format_type:
+            util.warn(
+                "PostgreSQL format_type() returned NULL for column '%s'"
+                % (name,)
+            )
+            coltype = sqltypes.NULLTYPE
+        else:
+            util.warn(
+                "Did not recognize type '%s' of column '%s'" % (attype, name)
+            )
+            coltype = sqltypes.NULLTYPE
+
+        # If a zero byte or blank string depending on driver (is also absent
+        # for older PG versions), then not a generated column. Otherwise, s =
+        # stored. (Other values might be added in the future.)
+        if generated not in (None, "", b"\x00"):
+            computed = dict(
+                sqltext=default, persisted=generated in ("s", b"s")
+            )
+            default = None
+        else:
+            computed = None
+
+        # adjust the default value
+        autoincrement = False
+        if default is not None:
+            match = re.search(r"""(nextval\(')([^']+)('.*$)""", default)
+            if match is not None:
+                if issubclass(coltype._type_affinity, sqltypes.Integer):
+                    autoincrement = True
+                # the default is related to a Sequence
+                sch = schema
+                if "." not in match.group(2) and sch is not None:
+                    # unconditionally quote the schema name.  this could
+                    # later be enhanced to obey quoting rules /
+                    # "quote schema"
+                    default = (
+                        match.group(1)
+                        + ('"%s"' % sch)
+                        + "."
+                        + match.group(2)
+                        + match.group(3)
+                    )
+
+        column_info = dict(
+            name=name,
+            type=coltype,
+            nullable=nullable,
+            default=default,
+            autoincrement=autoincrement or identity is not None,
+            comment=comment,
+        )
+        if computed is not None:
+            column_info["computed"] = computed
+        if identity is not None:
+            column_info["identity"] = identity
+        return column_info
+
+    def _get_redshift_column_info(self, *args, **kwargs):
         kw = kwargs.copy()
         encode = kw.pop('encode', None)
         if sa_version >= Version('1.3.16'):
@@ -993,7 +1244,7 @@ class RedshiftDialectMixin(DefaultDialect):
         elif sa_version >= Version('1.4.0') and 'identity' not in kw:
             kw['identity'] = None
 
-        column_info = super(RedshiftDialectMixin, self)._get_column_info(
+        column_info = self._get_column_info(
             *args,
             **kw
         )

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     py39-pg28-sa14
     py310-pg28-sa13
     py310-pg28-sa14
+    py310-pg28-sa20
     lint
     docs
 
@@ -13,6 +14,7 @@ passenv = PGPASSWORD,REDSHIFT_USERNAME,REDSHIFT_HOST,REDSHIFT_PORT,REDSHIFT_DATA
 deps =
     sa13: sqlalchemy==1.3.24
     sa14: sqlalchemy==1.4.15
+    sa20: sqlalchemy==2.0.23
     pg28: psycopg2==2.8.6
     pg29: psycopg2==2.9.5
     alembic==1.9.2


### PR DESCRIPTION
This PR builds on this [work done](https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/293/files) (open PR) adding support for SQLAlchemy 2.0 to make [reflection work](https://docs.sqlalchemy.org/en/20/core/reflection.html).

- Specifically, this PR copies 2 private functions `_load_domains` from `_get_column_info` from PGDailect from SQLAlchemy 1.4 release.
- Maps the 2.0 `multi` method for fetching objects to use fallback to single object methods in 1.4 and upstream redshift engine.